### PR TITLE
Centralize plugin configuration with validation

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,3 +2,6 @@ max_comment_line_length = false
 read_globals = {
   "vim",
 }
+globals = {
+  "vim.g",
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,47 @@
 # AGENTS.md
 
+## 🚨 CRITICAL: Git Commit Protocol 🚨
+
+**BEFORE EVERY `git commit` COMMAND:**
+
+### ✋ MANDATORY PRE-COMMIT CHECK
+```
+□ Did the user EXPLICITLY say "commit", "create a commit", or "you may commit"?
+□ If NO → STOP → ASK: "Should I create a commit?" → WAIT for response
+□ If YES → Proceed with commit process
+```
+
+### ⛔ NEVER Commit When User Says:
+- "continue"
+- "finish this" 
+- "next steps"
+- "implement it" (alone - this means do the work, NOT commit it)
+- ANY phrase without explicit "commit" permission
+
+### ✅ DO Commit When User Says:
+- "commit this"
+- "create a commit"
+- "you may commit"
+- "now commit"
+- "commit current changes before [next task]" (commit BEFORE starting next task, not after)
+
+### 📋 Required Steps When Given Permission:
+1. Run `git status` and `git diff` to see changes
+2. Run `git log --oneline -10` to check commit message style
+3. Draft commit message following conventional commits format
+4. Run `git add <files>` for relevant files
+5. Run `git commit -m "message"` with proper message
+6. Run `git status` after commit to verify
+7. **IMPORTANT**: After ONE commit, do NOT automatically commit again - wait for new permission
+
+### ⚠️ One Permission = One Commit
+- Each commit requires separate, explicit permission
+- Completing work does NOT mean permission to commit
+- After making a commit, STOP and report completion
+- Wait for new explicit permission before next commit
+
+---
+
 ## Build/Test Commands
 - **Lint**: `luacheck .` (configured in .luacheckrc)
 - **Format check**: `stylua --check lua/` (2-space indent, 80 char width, double quotes)

--- a/ftplugin/ada.lua
+++ b/ftplugin/ada.lua
@@ -1,0 +1,2 @@
+require("gnattest.read_only").setup()
+require("gnattest.ada_ls").setup()

--- a/ftplugin/ada.lua
+++ b/ftplugin/ada.lua
@@ -1,2 +1,3 @@
-require("gnattest.read_only").setup()
+require("gnattest.highlight").setup()
 require("gnattest.ada_ls").setup()
+require("gnattest.read_only").setup()

--- a/lua/gnattest/config.lua
+++ b/lua/gnattest/config.lua
@@ -1,0 +1,22 @@
+local default_opts = {
+  read_only = {
+    region_text = {
+      start = "begin read only",
+      ending = "end read only",
+    },
+  },
+}
+
+local M = {
+  opts = default_opts,
+}
+
+function M.get()
+  return M.opts
+end
+
+function M.set(opts)
+  M.opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+end
+
+return M

--- a/lua/gnattest/config.lua
+++ b/lua/gnattest/config.lua
@@ -1,4 +1,7 @@
 local default_opts = {
+  highlight = {
+    percent = 3,
+  },
   read_only = {
     enabled = true,
     region_text = {

--- a/lua/gnattest/config.lua
+++ b/lua/gnattest/config.lua
@@ -15,12 +15,37 @@ local M = {
   opts = default_opts,
 }
 
+local function is_valid(opts)
+  local notify = require("gnattest.utils").notify
+  if opts.read_only and opts.read_only.region_text then
+    local rt = opts.read_only.region_text
+    if type(rt.start) ~= "string" or type(rt.ending) ~= "string" then
+      notify(
+        "region_text.start and ending must be strings",
+        vim.log.levels.ERROR
+      )
+      return false
+    end
+  end
+
+  if opts.highlight and opts.highlight.percent then
+    if type(opts.highlight.percent) ~= "number" then
+      notify("highlight.percent must be a number", vim.log.levels.ERROR)
+      return false
+    end
+  end
+
+  return true
+end
+
 function M.get()
   return M.opts
 end
 
 function M.set(opts)
-  M.opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+  if is_valid(opts) then
+    M.opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+  end
 end
 
 return M

--- a/lua/gnattest/config.lua
+++ b/lua/gnattest/config.lua
@@ -1,5 +1,6 @@
 local default_opts = {
   read_only = {
+    enabled = true,
     region_text = {
       start = "begin read only",
       ending = "end read only",

--- a/lua/gnattest/config.lua
+++ b/lua/gnattest/config.lua
@@ -11,12 +11,29 @@ local default_opts = {
   },
 }
 
+local valid_keys = {
+  "highlight",
+  "read_only",
+}
+
 local M = {
   opts = default_opts,
 }
 
 local function is_valid(opts)
+  if opts == nil then
+    return true
+  end
+
   local notify = require("gnattest.utils").notify
+
+  for key in pairs(opts) do
+    if not vim.tbl_contains(valid_keys, key) then
+      notify("Unknown config field: " .. key, vim.log.levels.ERROR)
+      return false
+    end
+  end
+
   if opts.read_only and opts.read_only.region_text then
     local rt = opts.read_only.region_text
     if type(rt.start) ~= "string" or type(rt.ending) ~= "string" then

--- a/lua/gnattest/highlight.lua
+++ b/lua/gnattest/highlight.lua
@@ -1,7 +1,6 @@
-local M = {}
-
 local DEFAULT_HIGHLIGHT_COLOR = "#303030"
-local HIGHLIGHT_PERCENT_ADJUST = 3
+
+local M = {}
 
 -- Helper function to convert a Hex string (#RRGGBB) to an RGB table {r, g, b}
 local function hex_to_rgb(hex)
@@ -51,7 +50,7 @@ function M.set_highlight(namespace, hl_group)
   local hl = get_hl()
   local new_bg = DEFAULT_HIGHLIGHT_COLOR
 
-  local percent = HIGHLIGHT_PERCENT_ADJUST
+  local percent = M.opts.percent
 
   if vim.o.background == "light" then
     percent = -percent
@@ -65,8 +64,8 @@ function M.set_highlight(namespace, hl_group)
   vim.api.nvim_set_hl_ns(namespace)
 end
 
-function M.setup(opt)
-  M.opt = opt
+function M.setup()
+  M.opts = require("gnattest.config").get().highlight
 end
 
 -- Test-specific exports - only exposed in test mode

--- a/lua/gnattest/init.lua
+++ b/lua/gnattest/init.lua
@@ -1,29 +1,7 @@
-local default_opts = {
-  -- Region marker text (without comment syntax)
-  region_text = {
-    start = "begin read only",
-    ending = "end read only",
-  },
-}
-
-local M = {
-  opts = default_opts,
-}
+local M = {}
 
 function M.setup(opts)
-  vim.api.nvim_create_autocmd("BufReadPre", {
-    pattern = {
-      "*.ad[bs]",
-    },
-    callback = function()
-      if opts ~= nil and next(opts) ~= nil then
-        error("Options are not supported")
-      else
-        require("gnattest.read_only").setup(M.opts)
-        require("gnattest.ada_ls").setup()
-      end
-    end,
-  })
+  require("gnattest.config").set(opts)
 end
 
 return M

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -157,8 +157,8 @@ local function fix_ro_regions()
   end)
 end
 
-function M.setup(opt)
-  M.opt = opt
+function M.setup()
+  M.opt = require("gnattest.config").get()
 
   local gnattest_pattern = require("gnattest.utils").gnattest_pattern
 

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -158,7 +158,11 @@ local function fix_ro_regions()
 end
 
 function M.setup()
-  M.opt = require("gnattest.config").get()
+  M.opt = require("gnattest.config").get().read_only
+
+  if M.opt.enabled == false then
+    return
+  end
 
   local gnattest_pattern = require("gnattest.utils").gnattest_pattern
 

--- a/plugin/gnattest.lua
+++ b/plugin/gnattest.lua
@@ -1,5 +1,10 @@
 -- Define commands with subcommands, from: https://github.com/lumen-oss/nvim-best-practices?tab=readme-ov-file#speaking_head-user-commands
 
+if vim.g.loaded_gnattest then
+  return
+end
+vim.g.loaded_gnattest = true
+
 local utils = require("gnattest.utils")
 
 local cmd_name = "GNATtest"

--- a/plugin/gnattest.lua
+++ b/plugin/gnattest.lua
@@ -5,12 +5,10 @@ if vim.g.loaded_gnattest then
 end
 vim.g.loaded_gnattest = true
 
-local utils = require("gnattest.utils")
-
 local cmd_name = "GNATtest"
 
 local function clean_tests()
-  vim.cmd("!gprclean -P " .. utils.get_gnattest_project())
+  vim.cmd("!gprclean -P " .. require("gnattest.utils").get_gnattest_project())
 end
 
 local function generate_tests()
@@ -24,7 +22,7 @@ local function generate_tests()
 end
 
 local function build_tests()
-  vim.cmd("!gprbuild -P " .. utils.get_gnattest_project())
+  vim.cmd("!gprbuild -P " .. require("gnattest.utils").get_gnattest_project())
 end
 
 local function run_tests(filename, lnum)

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -1,0 +1,184 @@
+local helpers = require("spec.helpers.common")
+
+describe("gnattest.config", function()
+  local config
+
+  before_each(function()
+    helpers.mock_utils()
+
+    package.loaded["gnattest.config"] = nil
+    config = require("gnattest.config")
+  end)
+
+  after_each(function()
+    package.loaded["gnattest.config"] = nil
+    helpers.cleanup_packages()
+  end)
+
+  describe("default configuration", function()
+    it("should have default highlight config", function()
+      local opts = config.get()
+      assert.is_not_nil(opts.highlight)
+      assert.equals(3, opts.highlight.percent)
+    end)
+
+    it("should have default read_only config", function()
+      local opts = config.get()
+      assert.is_not_nil(opts.read_only)
+      assert.is_true(opts.read_only.enabled)
+      assert.equals("begin read only", opts.read_only.region_text.start)
+      assert.equals("end read only", opts.read_only.region_text.ending)
+    end)
+  end)
+
+  describe("set() with valid config", function()
+    it("should merge user config with defaults", function()
+      config.set({ highlight = { percent = 5 } })
+      local opts = config.get()
+      assert.equals(5, opts.highlight.percent)
+      assert.is_true(opts.read_only.enabled) -- defaults preserved
+    end)
+
+    it("should handle partial read_only config", function()
+      config.set({ read_only = { enabled = false } })
+      local opts = config.get()
+      assert.is_false(opts.read_only.enabled)
+      assert.equals("begin read only", opts.read_only.region_text.start) -- default preserved
+    end)
+
+    it("should handle nested region_text config", function()
+      config.set({
+        read_only = { region_text = { start = "LOCK", ending = "UNLOCK" } },
+      })
+      local opts = config.get()
+      assert.equals("LOCK", opts.read_only.region_text.start)
+      assert.equals("UNLOCK", opts.read_only.region_text.ending)
+    end)
+
+    it("should handle nil opts (use defaults)", function()
+      config.set(nil)
+      local opts = config.get()
+      assert.equals(3, opts.highlight.percent)
+      assert.is_true(opts.read_only.enabled)
+    end)
+
+    it("should handle empty table (use defaults)", function()
+      config.set({})
+      local opts = config.get()
+      assert.equals(3, opts.highlight.percent)
+      assert.is_true(opts.read_only.enabled)
+    end)
+  end)
+
+  describe("set() with multiple calls", function()
+    it("should allow updating config multiple times", function()
+      config.set({ highlight = { percent = 5 } })
+      assert.equals(5, config.get().highlight.percent)
+
+      config.set({ highlight = { percent = 10 } })
+      assert.equals(10, config.get().highlight.percent)
+    end)
+
+    it("should reset to defaults on each set()", function()
+      config.set({ highlight = { percent = 10 } })
+      config.set({ read_only = { enabled = false } })
+      local opts = config.get()
+      -- First config (highlight) should be reset to default
+      assert.equals(3, opts.highlight.percent)
+      -- Second config should be applied
+      assert.is_false(opts.read_only.enabled)
+    end)
+  end)
+
+  describe("validation - unknown fields", function()
+    it("should reject unknown top-level field", function()
+      local utils = require("gnattest.utils")
+      config.set({ unknown_field = "value" })
+
+      assert
+        .stub(utils.notify)
+        .was_called_with("Unknown config field: unknown_field", vim.log.levels.ERROR)
+
+      -- Config should not be updated
+      local opts = config.get()
+      assert.equals(3, opts.highlight.percent) -- still defaults
+    end)
+
+    it("should reject multiple unknown fields", function()
+      local utils = require("gnattest.utils")
+      config.set({ field1 = "a", field2 = "b" })
+
+      -- Should notify about at least one unknown field
+      assert.stub(utils.notify).was_called()
+    end)
+
+    it("should reject config with mix of valid and invalid fields", function()
+      local utils = require("gnattest.utils")
+      config.set({ highlight = { percent = 5 }, invalid = "bad" })
+
+      -- Should reject entire config
+      assert.stub(utils.notify).was_called()
+      local opts = config.get()
+      assert.equals(3, opts.highlight.percent) -- still defaults, not 5
+    end)
+  end)
+
+  describe("validation - type checking", function()
+    it("should reject non-string region_text.start", function()
+      local utils = require("gnattest.utils")
+      config.set({
+        read_only = { region_text = { start = 123, ending = "end" } },
+      })
+
+      assert
+        .stub(utils.notify)
+        .was_called_with("region_text.start and ending must be strings", vim.log.levels.ERROR)
+    end)
+
+    it("should reject non-string region_text.ending", function()
+      local utils = require("gnattest.utils")
+      config.set({
+        read_only = { region_text = { start = "start", ending = true } },
+      })
+
+      assert
+        .stub(utils.notify)
+        .was_called_with("region_text.start and ending must be strings", vim.log.levels.ERROR)
+    end)
+
+    it("should reject non-number highlight.percent", function()
+      local utils = require("gnattest.utils")
+      config.set({ highlight = { percent = "not a number" } })
+
+      assert
+        .stub(utils.notify)
+        .was_called_with("highlight.percent must be a number", vim.log.levels.ERROR)
+    end)
+
+    it("should accept valid types", function()
+      local utils = require("gnattest.utils")
+      config.set({
+        highlight = { percent = 10 },
+        read_only = { region_text = { start = "START", ending = "END" } },
+      })
+
+      assert.stub(utils.notify).was_not_called()
+      assert.equals(10, config.get().highlight.percent)
+    end)
+  end)
+
+  describe("get()", function()
+    it("should return current config", function()
+      local opts = config.get()
+      assert.is_table(opts)
+      assert.is_not_nil(opts.highlight)
+      assert.is_not_nil(opts.read_only)
+    end)
+
+    it("should return updated config after set()", function()
+      config.set({ highlight = { percent = 7 } })
+      local opts = config.get()
+      assert.equals(7, opts.highlight.percent)
+    end)
+  end)
+end)

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -4,6 +4,14 @@ local helpers = require("spec.helpers.common")
 describe("gnattest.highlight", function()
   local highlight
 
+  -- Helper function to reload highlight module with fresh config
+  -- Used when tests need to modify vim API behavior and reload the module
+  local function reload_highlight()
+    package.loaded["gnattest.highlight"] = nil
+    highlight = require("gnattest.highlight")
+    highlight.setup()
+  end
+
   before_each(function()
     -- Stub vim.o for background
     _G.vim.api = {
@@ -19,7 +27,19 @@ describe("gnattest.highlight", function()
     _G.vim.o = {
       background = "dark",
     }
-    highlight = require("gnattest.highlight")
+
+    -- Mock config module
+    package.preload["gnattest.config"] = function()
+      return {
+        get = function()
+          return {
+            highlight = { percent = 3 },
+          }
+        end,
+      }
+    end
+
+    reload_highlight()
   end)
 
   after_each(function()
@@ -34,16 +54,11 @@ describe("gnattest.highlight", function()
     assert.stub(_G.vim.api.nvim_set_hl_ns).was_called_with(123)
   end)
 
-  it("should store opts on setup", function()
-    highlight.setup({ foo = "bar" })
-    assert.same({ foo = "bar" }, highlight.opt)
-  end)
-
   it("should use default color when nvim_get_hl returns no bg", function()
     _G.vim.api.nvim_get_hl = function(_, _)
       return {}
     end
-    highlight = require("gnattest.highlight")
+    reload_highlight()
 
     highlight.set_highlight(123, "MyHighlight")
 
@@ -56,7 +71,7 @@ describe("gnattest.highlight", function()
     _G.vim.api.nvim_get_hl = function(_, _)
       return nil
     end
-    highlight = require("gnattest.highlight")
+    reload_highlight()
 
     highlight.set_highlight(123, "MyHighlight")
 
@@ -67,7 +82,7 @@ describe("gnattest.highlight", function()
 
   it("should lighten color for light background", function()
     _G.vim.o.background = "light"
-    highlight = require("gnattest.highlight")
+    reload_highlight()
 
     highlight.set_highlight(123, "MyHighlight")
 
@@ -166,7 +181,7 @@ describe("gnattest.highlight", function()
         _G.vim.api.nvim_get_hl = function(_, _)
           return {}
         end
-        highlight = require("gnattest.highlight")
+        reload_highlight()
         local hl = highlight._get_hl()
         assert.is_nil(hl)
       end)
@@ -175,7 +190,7 @@ describe("gnattest.highlight", function()
         _G.vim.api.nvim_get_hl = function(_, _)
           return nil
         end
-        highlight = require("gnattest.highlight")
+        reload_highlight()
         local hl = highlight._get_hl()
         assert.is_nil(hl)
       end)

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -1,66 +1,49 @@
 local stub_new = require("luassert.stub").new
-local helpers = require("spec.helpers.common")
 
 describe("gnattest.init", function()
   local gnattest_init
+  local config_mock
 
   before_each(function()
-    gnattest_init = require("gnattest.init")
-
-    _G.vim = {
-      api = helpers.create_basic_vim_api({
-        nvim_create_autocmd = stub_new(),
-      }),
+    -- Mock config module
+    config_mock = {
+      set = stub_new(),
     }
+    package.preload["gnattest.config"] = function()
+      return config_mock
+    end
 
-    package.preload["gnattest.utils"] = function()
-      return { gnattest_pattern = "**/gnattest/" }
-    end
-    package.preload["gnattest.read_only"] = function()
-      return { setup = stub_new() }
-    end
-    package.preload["gnattest.ada_ls"] = function()
-      return { setup = stub_new() }
-    end
+    package.loaded["gnattest.init"] = nil
+    gnattest_init = require("gnattest.init")
   end)
 
   after_each(function()
-    _G.vim = nil
-    package.preload["gnattest.utils"] = nil
-    package.preload["gnattest.read_only"] = nil
-    package.preload["gnattest.ada_ls"] = nil
+    package.preload["gnattest.config"] = nil
+    package.loaded["gnattest.config"] = nil
+    package.loaded["gnattest.init"] = nil
   end)
 
-  it("rejects unsupported options in setup", function()
-    local opts = { foo = "bar" }
-    assert.has_error(function()
-      _G.vim.api.nvim_create_autocmd = function(_, tbl)
-        -- simulate autocmd by calling callback
-        tbl.callback("BufReadPre")
-      end
+  describe("setup()", function()
+    it("should delegate to config.set() with nil", function()
+      gnattest_init.setup()
+      assert.stub(config_mock.set).was_called_with(nil)
+    end)
+
+    it("should delegate to config.set() with empty table", function()
+      gnattest_init.setup({})
+      assert.stub(config_mock.set).was_called_with({})
+    end)
+
+    it("should delegate to config.set() with options", function()
+      local opts = { highlight = { percent = 5 } }
       gnattest_init.setup(opts)
-      -- simulate autocmd callback directly, as nvim_create_autocmd only registers
-      -- we want to check error
-    end, "Options are not supported")
-  end)
+      assert.stub(config_mock.set).was_called_with(opts)
+    end)
 
-  it("calls read_only.setup and ada_ls.setup if no options", function()
-    local called_callback
-    _G.vim.api.nvim_create_autocmd = function(_, tbl)
-      tbl.callback("BufReadPre")
-      called_callback = true
-    end
-    gnattest_init.setup()
-    assert.is_true(called_callback)
-  end)
-
-  it("calls read_only.setup and ada_ls.setup if empty options", function()
-    local called_callback
-    _G.vim.api.nvim_create_autocmd = function(_, tbl)
-      tbl.callback("BufReadPre")
-      called_callback = true
-    end
-    gnattest_init.setup({})
-    assert.is_true(called_callback)
+    it("should pass through any options to config", function()
+      local opts = { read_only = { enabled = false } }
+      gnattest_init.setup(opts)
+      assert.stub(config_mock.set).was_called_with(opts)
+    end)
   end)
 end)

--- a/spec/read_only_spec.lua
+++ b/spec/read_only_spec.lua
@@ -5,6 +5,30 @@ describe("gnattest.read_only", function()
   local ro
   local autocmd_callbacks = {}
 
+  -- Helper function to mock the config module with custom read_only options
+  -- This reduces duplication and makes tests more maintainable
+  local function mock_config(read_only_opts)
+    package.loaded["gnattest.config"] = nil
+    package.preload["gnattest.config"] = function()
+      return {
+        get = function()
+          return { read_only = read_only_opts }
+        end,
+      }
+    end
+  end
+
+  -- Helper to setup default config (used by most tests)
+  local function setup_default_config()
+    mock_config({
+      enabled = true,
+      region_text = {
+        start = "begin read only",
+        ending = "end read only",
+      },
+    })
+  end
+
   before_each(function()
     autocmd_callbacks = {}
 
@@ -80,44 +104,69 @@ describe("gnattest.read_only", function()
     })
 
     package.preload["gnattest.highlight"] = function()
-      return { set_highlight = stub.new() }
+      return {
+        set_highlight = stub.new(),
+        setup = function() end,
+      }
     end
+
+    -- Setup default config for most tests
+    setup_default_config()
+
     ro = require("gnattest.read_only")
   end)
 
   after_each(function()
     common.cleanup_packages()
     package.preload["gnattest.highlight"] = nil
+    package.loaded["gnattest.config"] = nil
+    package.preload["gnattest.config"] = nil
   end)
 
-  it("should store opts on setup", function()
-    ro.setup({ foo = "bar" })
-    assert.same({ foo = "bar" }, ro.opt)
+  it("should retrieve config from centralized config module", function()
+    ro.setup()
+    assert.is_table(ro.opt)
+    assert.is_equal(true, ro.opt.enabled)
+    assert.is_equal("begin read only", ro.opt.region_text.start)
+    assert.is_equal("end read only", ro.opt.region_text.ending)
+  end)
+
+  it("should not create autocommands when read_only is disabled", function()
+    mock_config({
+      enabled = false,
+      region_text = {
+        start = "begin read only",
+        ending = "end read only",
+      },
+    })
+    autocmd_callbacks = {}
+    ro.setup()
+    assert.is_equal(0, #autocmd_callbacks)
   end)
 
   describe("setup autocommands", function()
     it("should create autocommands", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.stub(_G.vim.api.nvim_create_autocmd).was_called()
     end)
 
     it("should create three autocommand groups", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_equal(3, #autocmd_callbacks)
     end)
 
     it("should create ColorScheme autocommand", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_equal("ColorScheme", autocmd_callbacks[1].event)
     end)
 
     it("should create BufReadPost autocommand", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_equal("BufReadPost", autocmd_callbacks[2].event)
     end)
 
     it("should create TextChanged autocommand", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local text_changed = autocmd_callbacks[3]
       assert.is_table(text_changed.event)
       assert.is_equal("TextChanged", text_changed.event[1])
@@ -125,14 +174,14 @@ describe("gnattest.read_only", function()
     end)
 
     it("should set group for all autocommands", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       for _, callback in ipairs(autocmd_callbacks) do
         assert.is_equal("autest", callback.opts.group)
       end
     end)
 
     it("should set pattern for file-specific autocommands", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_table(autocmd_callbacks[2].opts.pattern)
       assert.is_string(autocmd_callbacks[2].opts.pattern[1])
     end)
@@ -143,11 +192,10 @@ describe("gnattest.read_only", function()
       assert.is_table(ro.extmark)
     end)
 
-    it("should store options after setup", function()
-      local opts = { region_text = { start = "begin", ending = "end" } }
-      ro.setup(opts)
-      assert.is_equal("begin", ro.opt.region_text.start)
-      assert.is_equal("end", ro.opt.region_text.ending)
+    it("should store options from config after setup", function()
+      ro.setup()
+      assert.is_equal("begin read only", ro.opt.region_text.start)
+      assert.is_equal("end read only", ro.opt.region_text.ending)
     end)
   end)
 
@@ -162,20 +210,25 @@ describe("gnattest.read_only", function()
   describe("error handling", function()
     it("should handle empty options", function()
       assert.has_no_error(function()
-        ro.setup({})
+        ro.setup()
       end)
     end)
 
-    it("should handle multiple setups", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
-      ro.setup({ region_text = { start = "start", ending = "finish" } })
+    it("should handle multiple setups with different configs", function()
+      ro.setup()
+      -- Update config to different values
+      mock_config({
+        enabled = true,
+        region_text = { start = "start", ending = "finish" },
+      })
+      ro.setup()
       assert.is_equal("start", ro.opt.region_text.start)
     end)
   end)
 
   describe("callback execution", function()
     it("should invoke ColorScheme callback", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local colorscheme_callback = autocmd_callbacks[1].opts.callback
       assert.is_not_nil(colorscheme_callback)
       assert.has_no_error(function()
@@ -184,7 +237,7 @@ describe("gnattest.read_only", function()
     end)
 
     it("should invoke BufReadPost callback", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local bufread_callback = autocmd_callbacks[2].opts.callback
       assert.is_not_nil(bufread_callback)
       assert.has_no_error(function()
@@ -193,7 +246,7 @@ describe("gnattest.read_only", function()
     end)
 
     it("should call highlight.set_highlight on ColorScheme event", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local hl = require("gnattest.highlight")
       local colorscheme_callback = autocmd_callbacks[1].opts.callback
       colorscheme_callback()
@@ -201,7 +254,7 @@ describe("gnattest.read_only", function()
     end)
 
     it("should call notify when protected region is changed", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local utils = require("gnattest.utils")
       assert.is_not_nil(utils.notify)
     end)
@@ -209,26 +262,32 @@ describe("gnattest.read_only", function()
 
   describe("region marker recognition", function()
     it("should accept custom start marker", function()
-      ro.setup({ region_text = { start = "LOCK", ending = "UNLOCK" } })
+      mock_config({
+        enabled = true,
+        region_text = { start = "LOCK", ending = "UNLOCK" },
+      })
+      ro.setup()
       assert.is_equal("LOCK", ro.opt.region_text.start)
     end)
 
     it("should accept custom end marker", function()
-      ro.setup({ region_text = { start = "LOCK", ending = "UNLOCK" } })
+      mock_config({
+        enabled = true,
+        region_text = { start = "LOCK", ending = "UNLOCK" },
+      })
+      ro.setup()
       assert.is_equal("UNLOCK", ro.opt.region_text.ending)
     end)
 
     it("should handle default markers", function()
-      ro.setup({
-        region_text = { start = "begin read only", ending = "end read only" },
-      })
+      ro.setup()
       assert.is_equal("begin read only", ro.opt.region_text.start)
     end)
   end)
 
   describe("diff mode detection", function()
     it("should handle diff mode states correctly", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
 
       -- Default diff mode should be false
       assert.is_false(_G.vim.opt.diff:get())
@@ -249,12 +308,12 @@ describe("gnattest.read_only", function()
 
   describe("highlight integration", function()
     it("should set hl_group on highlight namespace", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_equal("hl_ro", ro.hl_group)
     end)
 
     it("should call set_highlight on ColorScheme event", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local hl = require("gnattest.highlight")
       local colorscheme_cb = autocmd_callbacks[1].opts.callback
       colorscheme_cb()
@@ -264,16 +323,14 @@ describe("gnattest.read_only", function()
 
   describe("extmark data structure", function()
     it("should store line data in extmark table", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_table(ro.extmark)
     end)
 
     it("should preserve extmark across operations", function()
-      local opts1 = { region_text = { start = "a", ending = "b" } }
-      ro.setup(opts1)
+      ro.setup()
 
-      local opts2 = { region_text = { start = "c", ending = "d" } }
-      ro.setup(opts2)
+      ro.setup()
       -- Extmark table should be preserved (same reference or new table)
       assert.is_table(ro.extmark)
     end)
@@ -281,9 +338,7 @@ describe("gnattest.read_only", function()
 
   describe("region detection", function()
     it("should get comments from utils", function()
-      ro.setup({
-        region_text = { start = "begin read only", ending = "end read only" },
-      })
+      ro.setup()
       local utils = require("gnattest.utils")
       local comments = utils.get_all_comments()
       assert.is_table(comments)
@@ -291,9 +346,7 @@ describe("gnattest.read_only", function()
     end)
 
     it("should parse region markers from comments", function()
-      ro.setup({
-        region_text = { start = "begin read only", ending = "end read only" },
-      })
+      ro.setup()
       local utils = require("gnattest.utils")
       local comments = utils.get_all_comments()
       assert.is_equal("--begin read only", comments[1].text)
@@ -303,7 +356,7 @@ describe("gnattest.read_only", function()
 
   describe("state consistency", function()
     it("should maintain consistent state after setup operations", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       assert.is_not_nil(ro.namespace)
       assert.is_not_nil(ro.ro_group)
       assert.is_not_nil(ro.hl_group)
@@ -312,8 +365,8 @@ describe("gnattest.read_only", function()
       -- Namespace and augroup should remain stable across setups
       local ns_before = ro.namespace
       local group_before = ro.ro_group
-      ro.setup({ foo = "bar" })
-      ro.setup({ region_text = { start = "a", ending = "b" } })
+      ro.setup()
+      ro.setup()
 
       assert.is_equal(ns_before, ro.namespace)
       assert.is_equal(group_before, ro.ro_group)
@@ -322,7 +375,7 @@ describe("gnattest.read_only", function()
 
   describe("vim API integration", function()
     it("should use required vim API functions and log levels", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local bufread_callback = autocmd_callbacks[2].opts.callback
       bufread_callback()
 
@@ -335,7 +388,7 @@ describe("gnattest.read_only", function()
 
   describe("pattern configuration", function()
     it("should use correct gnattest patterns for file matching", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local utils = require("gnattest.utils")
 
       assert.is_table(utils.gnattest_pattern)
@@ -344,9 +397,7 @@ describe("gnattest.read_only", function()
 
   describe("comment parsing edge cases", function()
     it("should handle comments with and without region markers", function()
-      ro.setup({
-        region_text = { start = "begin read only", ending = "end read only" },
-      })
+      ro.setup()
       local utils = require("gnattest.utils")
       local comments = utils.get_all_comments()
       assert.is_table(comments)
@@ -356,7 +407,7 @@ describe("gnattest.read_only", function()
 
   describe("region protection notifications", function()
     it("should use notification system with ERROR log level", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local utils = require("gnattest.utils")
       assert.is_not_nil(utils.notify)
       assert.is_equal(4, _G.vim.log.levels.ERROR)
@@ -365,7 +416,7 @@ describe("gnattest.read_only", function()
 
   describe("fix_ro_regions logic", function()
     it("should have required vim APIs for region processing", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
 
       assert.is_not_nil(_G.vim.schedule)
       assert.is_not_nil(_G.vim.api.nvim_buf_get_extmarks)
@@ -380,7 +431,7 @@ describe("gnattest.read_only", function()
     it(
       "should handle backup, change detection, protection, and mark restoration",
       function()
-        ro.setup({ region_text = { start = "begin", ending = "end" } })
+        ro.setup()
 
         -- Backup mechanism: Trigger BufReadPost to create backup
         local bufread_callback = autocmd_callbacks[2].opts.callback
@@ -407,9 +458,7 @@ describe("gnattest.read_only", function()
 
   describe("full workflow simulation", function()
     it("should handle BufReadPost callback operations correctly", function()
-      ro.setup({
-        region_text = { start = "begin read only", ending = "end read only" },
-      })
+      ro.setup()
 
       local bufread_callback = autocmd_callbacks[2].opts.callback
 
@@ -428,19 +477,27 @@ describe("gnattest.read_only", function()
 
   describe("configuration persistence", function()
     it("should maintain and update options correctly", function()
-      ro.setup({ region_text = { start = "TEST_START", ending = "TEST_END" } })
+      mock_config({
+        enabled = true,
+        region_text = { start = "TEST_START", ending = "TEST_END" },
+      })
+      ro.setup()
       local bufread_callback = autocmd_callbacks[2].opts.callback
       bufread_callback()
       assert.is_equal("TEST_START", ro.opt.region_text.start)
 
-      ro.setup({ region_text = { start = "NEW", ending = "NEW_END" } })
+      mock_config({
+        enabled = true,
+        region_text = { start = "NEW", ending = "NEW_END" },
+      })
+      ro.setup()
       assert.is_equal("NEW", ro.opt.region_text.start)
     end)
   end)
 
   describe("region modification detection and protection", function()
     it("should handle region protection scenarios correctly", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local utils = require("gnattest.utils")
       local bufread_callback = autocmd_callbacks[2].opts.callback
       bufread_callback()
@@ -488,7 +545,7 @@ describe("gnattest.read_only", function()
     end)
 
     it("exercises extmarks with details and overlap options", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       _G.vim.opt.diff.get = function()
         return false
       end
@@ -504,7 +561,7 @@ describe("gnattest.read_only", function()
     end)
 
     it("uses extmarks with details and overlap options", function()
-      ro.setup({ region_text = { start = "begin", ending = "end" } })
+      ro.setup()
       local bufread_callback = autocmd_callbacks[2].opts.callback
       bufread_callback()
 
@@ -557,7 +614,7 @@ describe("gnattest.read_only", function()
       it(
         "_fix_ro_regions calls vim.api.nvim_buf_get_extmarks with details and overlap",
         function()
-          ro.setup({ region_text = { start = "begin", ending = "end" } })
+          ro.setup()
           local bufread_callback = autocmd_callbacks[2].opts.callback
           bufread_callback()
 

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -248,6 +248,24 @@ describe("gnattest.utils", function()
     end)
   end)
 
+  describe("get_gnattest_project()", function()
+    it("returns path to test_driver.gpr in harness directory", function()
+      package.preload["gnattest.ada_ls"] = function()
+        return {
+          get_harness_dir = function()
+            return "/project/obj/gnattest/harness"
+          end,
+        }
+      end
+      package.loaded["gnattest.utils"] = nil
+      utils = require("gnattest.utils")
+      assert.equals(
+        "/project/obj/gnattest/harness/test_driver.gpr",
+        utils.get_gnattest_project()
+      )
+    end)
+  end)
+
   describe("is_gnattest_file() alternative detection", function()
     it("detects file in harness_dir when gnattest not in path", function()
       package.loaded["gnattest.utils"] = nil


### PR DESCRIPTION
Refactors configuration into a centralized module, enabling users to customize highlight intensity and disable read-only protection through a single `setup()` call. Setup is optional - plugin auto-initializes with sensible defaults.

**Key changes:**
- New `lua/gnattest/config.lua` - centralized config with validation
- Configurable highlight percentage and optional read-only protection
- Simplified `init.lua` (29 → 7 lines)
- Fixed lazy loading guard in `plugin/gnattest.lua`