### PR TITLE
Correctly switch from overriden subprogram test

### DIFF
--- a/lua/gnattest/navigation.lua
+++ b/lua/gnattest/navigation.lua
@@ -59,17 +59,14 @@ local function get_gnattest_info_on_cursor()
     return nil
   end
 
-  local filename = utils.get_filename()
-
   local subr_name, start_pos = get_subprogram_name()
   if subr_name == nil then
     return nil
   end
 
-  local search_file_flag = false
-
+  local filename
   if utils.is_gnattest_file() then
-    search_file_flag = true
+    filename = utils.get_filename()
   else
     if start_pos ~= nil then
       vim.api.nvim_win_set_cursor(0, start_pos)
@@ -84,14 +81,17 @@ local function get_gnattest_info_on_cursor()
   for f, file_info in pairs(xml_info) do
     for _, pkg_info in pairs(file_info) do
       for _, info in pairs(pkg_info) do
-        if not search_file_flag then
+        if not utils.is_gnattest_file() then
           if
             vim.fn.match(f, filename) == 0
             and vim.fn.match(info.source.name, subr_name) ~= -1
           then
             return { [f] = info }
           end
-        elseif vim.fn.match(info.test.name, subr_name) ~= -1 then
+        elseif
+          vim.fn.match(info.test.file, filename) == 0
+          and vim.fn.match(info.test.name, subr_name) ~= -1
+        then
           return { [f] = info }
         end
       end

--- a/spec/navigation_spec.lua
+++ b/spec/navigation_spec.lua
@@ -267,6 +267,7 @@ describe("gnattest.navigation", function()
 
       it("searches by test name when in gnattest file", function()
         utils_mock.is_gnattest_file.returns(true)
+        utils_mock.get_filename.returns("test_file.adb")
         local test_entry =
           create_xml_test_entry("My_Function", "Test_My_Function")
         xml_mock.get_xml_info.returns({
@@ -386,6 +387,7 @@ describe("gnattest.navigation", function()
 
     it("switches to source file when in gnattest file", function()
       utils_mock.is_gnattest_file.returns(true)
+      utils_mock.get_filename.returns("test_file.adb")
       xml_mock.get_xml_info.returns({
         ["my_package.ads"] = {
           ["Package1"] = {
@@ -415,6 +417,7 @@ describe("gnattest.navigation", function()
 
     it("returns nil when src_dirs not available", function()
       utils_mock.is_gnattest_file.returns(true)
+      utils_mock.get_filename.returns("test_file.adb")
       xml_mock.get_xml_info.returns({
         ["my_package.ads"] = {
           ["Package1"] = {
@@ -466,6 +469,7 @@ describe("gnattest.navigation", function()
 
     it("handles multiple file entries correctly", function()
       utils_mock.is_gnattest_file.returns(true)
+      utils_mock.get_filename.returns("test_file.adb")
       xml_mock.get_xml_info.returns({
         ["my_package.ads"] = {
           ["Package1"] = {


### PR DESCRIPTION
This PR fixes an issue where switching from a test of an overridden subprogram would navigate to the parent's declaration instead of the child's implementation.
The file-matching logic is now more specific, ensuring the correct source file is always found.

Closes #16