### PR TITLE
Fix read-only errors after regenerate (fixes #19)

### DIFF
--- a/lua/gnattest/health.lua
+++ b/lua/gnattest/health.lua
@@ -77,7 +77,7 @@ local function check_project_structure()
 
   local lsp_ok, client = check_lsp_client()
 
-  if not lsp_ok then
+  if not lsp_ok or client == nil then
     return
   end
 
@@ -119,10 +119,11 @@ local function check_project_structure()
       )
     end
   else
-    vim.health.info("GNATtest project structure not detected", {
-      "This may be a regular Ada project without GNATtest",
-      "Run :Gnattest generate to create test harness",
-    })
+    vim.health.info([[
+      GNATtest project structure not detected
+      This may be a regular Ada project without GNATtest
+      Run :Gnattest generate to create test harness
+      ]])
   end
 end
 

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -212,11 +212,11 @@ function M.setup()
     end,
   })
 
-  vim.api.nvim_create_autocmd("BufReadPost", {
+  vim.api.nvim_create_autocmd({ "BufReadPost", "BufWinEnter" }, {
     group = M.ro_group,
     pattern = gnattest_pattern,
     callback = function()
-      prepare_gnattest()
+      M.refresh()
     end,
   })
 

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -115,6 +115,12 @@ local function protected_region_notif()
 end
 
 local function prepare_gnattest()
+  M.opt = require("gnattest.config").get().read_only
+  if M.opt.enabled == false then
+    clear()
+    return
+  end
+
   comments = require("gnattest.utils").get_all_comments("ada")
   get_regions(set_extmark)
   require("gnattest.highlight").set_highlight(M.namespace, M.hl_group)
@@ -130,6 +136,12 @@ local function fix_ro_regions()
   end
 
   vim.schedule(function()
+    M.opt = require("gnattest.config").get().read_only
+    if M.opt.enabled == false then
+      clear()
+      return
+    end
+
     local cursor_pos = vim.fn.getpos(".")
     local lnum = cursor_pos[2]
     local cnum = cursor_pos[3]

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -34,6 +34,24 @@ local function parse_comment(comment)
   return nil
 end
 
+local function clear_extmarks()
+  local bufid = require("gnattest.utils").get_bufid()
+  vim.api.nvim_buf_clear_namespace(
+    require("gnattest.utils").get_bufid(),
+    M.namespace,
+    bufid,
+    -1
+  )
+  M.extmark = {}
+end
+
+local function clear()
+  clear_extmarks()
+  comments = {}
+  protect_flag = false
+  M.backup = nil
+end
+
 -- Use mark_id to update an extmark
 local function set_extmark(start_row, end_row, mark_id)
   local opt = {
@@ -159,6 +177,11 @@ local function fix_ro_regions()
       end
     end
   end)
+end
+
+function M.refresh()
+  clear()
+  prepare_gnattest()
 end
 
 function M.setup()

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -196,6 +196,40 @@ local function refresh()
   prepare_gnattest()
 end
 
+local function conform_workaround()
+  local is_ro_enabled = require("gnattest.config").get().read_only.enabled
+  if is_ro_enabled == false then
+    return
+  end
+
+  vim.api.nvim_create_autocmd("User", {
+    group = M.ro_group,
+    pattern = "ConformFormatPre",
+    callback = function()
+      is_ro_enabled = require("gnattest.config").get().read_only.enabled
+      -- This is a workaround for conform.nvim, which doesn't trigger TextChanged events during formatting.
+      -- By refreshing the read-only regions before formatting, we ensure that any changes made by the formatter
+      -- are correctly handled and that the read-only regions are properly protected.
+      ---@diagnostic disable-next-line: missing-fields
+      require("gnattest.config").set({ read_only = { enabled = false } })
+    end,
+  })
+  vim.api.nvim_create_autocmd("User", {
+    group = M.ro_group,
+    pattern = "ConformFormatPost",
+    callback = function()
+      if is_ro_enabled == false then
+        return
+      end
+      -- After formatting is done, we need to fix the read-only regions again to ensure that any changes made by the formatter
+      -- are correctly handled and that the read-only regions are properly protected.
+      ---@diagnostic disable-next-line: missing-fields
+      require("gnattest.config").set({ read_only = { enabled = true } })
+      vim.schedule(refresh)
+    end,
+  })
+end
+
 function M.setup()
   M.opt = require("gnattest.config").get().read_only
 
@@ -232,6 +266,8 @@ function M.setup()
       fix_ro_regions()
     end,
   })
+
+  conform_workaround()
 end
 
 function M.reset()

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -191,7 +191,7 @@ local function fix_ro_regions()
   end)
 end
 
-function M.refresh()
+local function refresh()
   clear()
   prepare_gnattest()
 end
@@ -212,11 +212,11 @@ function M.setup()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "BufReadPost", "BufWinEnter" }, {
+  vim.api.nvim_create_autocmd({ "BufReadPost", "BufWinEnter", "BufEnter" }, {
     group = M.ro_group,
     pattern = gnattest_pattern,
     callback = function()
-      M.refresh()
+      refresh()
     end,
   })
 
@@ -232,6 +232,11 @@ function M.setup()
       fix_ro_regions()
     end,
   })
+end
+
+function M.reset()
+  refresh()
+  M.setup()
 end
 
 -- Test-specific exports - only exposed in test mode

--- a/lua/gnattest/utils.lua
+++ b/lua/gnattest/utils.lua
@@ -87,7 +87,8 @@ function M.set_gnattest_pattern()
 end
 
 function M.get_lines(start_row, end_row)
-  return vim.api.nvim_buf_get_lines(0, start_row, end_row + 1, true)
+  local bufid = M.get_bufid()
+  return vim.api.nvim_buf_get_lines(bufid, start_row, end_row + 1, true)
 end
 
 function M.find_file(filename, path)
@@ -141,10 +142,17 @@ function M.get_all_comments(language)
     return {}
   end
 
-  for id, node in query:iter_captures(root, 0) do
+  local bufid = require("gnattest.utils").get_bufid()
+
+  for id, node in query:iter_captures(root, bufid) do
     if query.captures[id] == "comment" then
       local start_row = node:range()
-      local text = vim.treesitter.get_node_text(node, 0)
+      local text
+      ok, text = pcall(vim.treesitter.get_node_text, node, bufid)
+      if not ok or text == "" then
+        return {}
+      end
+
       table.insert(cmts, {
         node = node,
         text = text:gsub("^%s*", ""):gsub("%s*$", ""), -- Trim whitespace

--- a/lua/gnattest/xml.lua
+++ b/lua/gnattest/xml.lua
@@ -56,8 +56,8 @@ local function create_xml_buf()
   return buf_id
 end
 
-function M.get_xml_info()
-  if next(xml_info) ~= nil then
+function M.get_xml_info(refresh)
+  if next(xml_info) ~= nil and refresh ~= true then
     return xml_info
   end
 

--- a/plugin/gnattest.lua
+++ b/plugin/gnattest.lua
@@ -15,11 +15,21 @@ end
 
 local function generate_tests()
   local ada_ls = require("gnattest.ada_ls").get_ada_ls()
+
   if ada_ls ~= nil then
     local json_file = ada_ls.config.root_dir .. "/.als.json"
     local config = vim.fn.json_decode(vim.fn.readfile(json_file))
 
-    vim.cmd("!gnattest -P " .. config.projectFile)
+    local obj = vim
+      .system({ "gnattest", "-P" .. config.projectFile }, { text = true })
+      :wait()
+    if obj.code ~= 0 then
+      print("Error generating tests: Process exited with code " .. obj.code)
+    else
+      print("Tests generated successfully")
+    end
+
+    require("gnattest.xml").get_xml_info(true) -- Refresh XML info after generating tests
   end
 end
 

--- a/plugin/gnattest.lua
+++ b/plugin/gnattest.lua
@@ -27,7 +27,6 @@ local function generate_tests()
     if disable_ro then
       ---@diagnostic disable-next-line: missing-fields
       require("gnattest.config").set({ read_only = { enabled = false } })
-      vim.cmd("write") -- Save the file to trigger the read-only extmarks to be cleared
     end
 
     local obj = vim
@@ -40,8 +39,7 @@ local function generate_tests()
     end
 
     if disable_ro then
-      vim.cmd("write") -- Save the file to trigger the read-only extmarks to be set again
-      require("gnattest.read_only").refresh()
+      require("gnattest.read_only").reset()
       ---@diagnostic disable-next-line: missing-fields
       require("gnattest.config").set({ read_only = { enabled = true } })
     end

--- a/plugin/gnattest.lua
+++ b/plugin/gnattest.lua
@@ -15,10 +15,20 @@ end
 
 local function generate_tests()
   local ada_ls = require("gnattest.ada_ls").get_ada_ls()
+  local utils = require("gnattest.utils")
 
   if ada_ls ~= nil then
     local json_file = ada_ls.config.root_dir .. "/.als.json"
     local config = vim.fn.json_decode(vim.fn.readfile(json_file))
+
+    local ro_config = require("gnattest.config").get().read_only
+    local is_read_only_enabled = ro_config.enabled
+    local disable_ro = is_read_only_enabled and utils.is_gnattest_file()
+    if disable_ro then
+      ---@diagnostic disable-next-line: missing-fields
+      require("gnattest.config").set({ read_only = { enabled = false } })
+      vim.cmd("write") -- Save the file to trigger the read-only extmarks to be cleared
+    end
 
     local obj = vim
       .system({ "gnattest", "-P" .. config.projectFile }, { text = true })
@@ -27,6 +37,13 @@ local function generate_tests()
       print("Error generating tests: Process exited with code " .. obj.code)
     else
       print("Tests generated successfully")
+    end
+
+    if disable_ro then
+      vim.cmd("write") -- Save the file to trigger the read-only extmarks to be set again
+      require("gnattest.read_only").refresh()
+      ---@diagnostic disable-next-line: missing-fields
+      require("gnattest.config").set({ read_only = { enabled = true } })
     end
 
     require("gnattest.xml").get_xml_info(true) -- Refresh XML info after generating tests

--- a/spec/navigation_spec.lua
+++ b/spec/navigation_spec.lua
@@ -228,6 +228,19 @@ describe("gnattest.navigation", function()
       assert.stub(ada_ls_mock.get_src_dirs).was_called()
     end)
 
+    it("returns nil when find_file returns nil", function()
+      utils_mock.is_gnattest_file.returns(true)
+      xml_mock.get_gnattest_info_on_cursor.returns(
+        "my_package.ads",
+        "Package1",
+        create_xml_test_entry("My_Function", "Test_My_Function")
+      )
+      ada_ls_mock.get_src_dirs.returns({ "/project/src" })
+      utils_mock.find_file.returns(nil)
+
+      assert.is_nil(navigation.switch_subprogram())
+    end)
+
     it("switches to test file when in source file", function()
       utils_mock.is_gnattest_file.returns(false)
       utils_mock.get_filename.returns("my_package.ads")

--- a/spec/read_only_spec.lua
+++ b/spec/read_only_spec.lua
@@ -5,20 +5,22 @@ describe("gnattest.read_only", function()
   local ro
   local autocmd_callbacks = {}
 
-  -- Helper function to mock the config module with custom read_only options
-  -- This reduces duplication and makes tests more maintainable
   local function mock_config(read_only_opts)
     package.loaded["gnattest.config"] = nil
+    local config_mock = {
+      set = stub.new(),
+    }
     package.preload["gnattest.config"] = function()
       return {
         get = function()
           return { read_only = read_only_opts }
         end,
+        set = config_mock.set,
       }
     end
+    return config_mock
   end
 
-  -- Helper to setup default config (used by most tests)
   local function setup_default_config()
     mock_config({
       enabled = true,
@@ -27,6 +29,10 @@ describe("gnattest.read_only", function()
         ending = "end read only",
       },
     })
+  end
+
+  local function get_callback(index)
+    return autocmd_callbacks[index].opts.callback
   end
 
   before_each(function()
@@ -42,6 +48,7 @@ describe("gnattest.read_only", function()
       nvim_create_autocmd = stub.new().invokes(function(event, opts)
         table.insert(autocmd_callbacks, { event = event, opts = opts })
       end),
+      nvim_buf_clear_namespace = stub.new(),
       nvim_buf_set_extmark = stub.new().returns(42),
       nvim_get_current_buf = function()
         return 0
@@ -86,8 +93,10 @@ describe("gnattest.read_only", function()
     _G.vim.schedule = function(cb)
       cb()
     end
+    _G.vim.deep_equal = function()
+      return true
+    end
 
-    -- Mock utils with read_only-specific methods
     common.mock_utils({
       get_lines = function(start_row, end_row)
         if start_row == 1 and end_row == 2 then
@@ -110,7 +119,6 @@ describe("gnattest.read_only", function()
       }
     end
 
-    -- Setup default config for most tests
     setup_default_config()
 
     ro = require("gnattest.read_only")
@@ -123,416 +131,114 @@ describe("gnattest.read_only", function()
     package.preload["gnattest.config"] = nil
   end)
 
-  it("should retrieve config from centralized config module", function()
-    ro.setup()
-    assert.is_table(ro.opt)
-    assert.is_equal(true, ro.opt.enabled)
-    assert.is_equal("begin read only", ro.opt.region_text.start)
-    assert.is_equal("end read only", ro.opt.region_text.ending)
-  end)
-
-  it("should not create autocommands when read_only is disabled", function()
-    mock_config({
-      enabled = false,
-      region_text = {
-        start = "begin read only",
-        ending = "end read only",
-      },
-    })
-    autocmd_callbacks = {}
-    ro.setup()
-    assert.is_equal(0, #autocmd_callbacks)
-  end)
-
-  describe("setup autocommands", function()
-    it("should create autocommands", function()
+  describe("setup", function()
+    it("loads config and registers autocmds", function()
       ro.setup()
-      assert.stub(_G.vim.api.nvim_create_autocmd).was_called()
-    end)
 
-    it("should create three autocommand groups", function()
-      ro.setup()
-      assert.is_equal(3, #autocmd_callbacks)
-    end)
+      assert.is_table(ro.opt)
+      assert.is_true(ro.opt.enabled)
+      assert.equals("begin read only", ro.opt.region_text.start)
+      assert.equals("end read only", ro.opt.region_text.ending)
 
-    it("should create ColorScheme autocommand", function()
-      ro.setup()
-      assert.is_equal("ColorScheme", autocmd_callbacks[1].event)
-    end)
+      assert.equals(5, #autocmd_callbacks)
+      assert.equals("ColorScheme", autocmd_callbacks[1].event)
 
-    it("should create BufReadPost autocommand", function()
-      ro.setup()
-      assert.is_equal("BufReadPost", autocmd_callbacks[2].event)
-    end)
+      assert.is_table(autocmd_callbacks[2].event)
+      assert.equals("BufReadPost", autocmd_callbacks[2].event[1])
+      assert.equals("BufWinEnter", autocmd_callbacks[2].event[2])
+      assert.equals("BufEnter", autocmd_callbacks[2].event[3])
 
-    it("should create TextChanged autocommand", function()
-      ro.setup()
-      local text_changed = autocmd_callbacks[3]
-      assert.is_table(text_changed.event)
-      assert.is_equal("TextChanged", text_changed.event[1])
-      assert.is_equal("TextChangedI", text_changed.event[2])
-    end)
+      assert.is_table(autocmd_callbacks[3].event)
+      assert.equals("TextChanged", autocmd_callbacks[3].event[1])
+      assert.equals("TextChangedI", autocmd_callbacks[3].event[2])
 
-    it("should set group for all autocommands", function()
-      ro.setup()
+      assert.equals("User", autocmd_callbacks[4].event)
+      assert.equals("ConformFormatPre", autocmd_callbacks[4].opts.pattern)
+      assert.equals("User", autocmd_callbacks[5].event)
+      assert.equals("ConformFormatPost", autocmd_callbacks[5].opts.pattern)
+
       for _, callback in ipairs(autocmd_callbacks) do
-        assert.is_equal("autest", callback.opts.group)
+        assert.equals("autest", callback.opts.group)
       end
-    end)
 
-    it("should set pattern for file-specific autocommands", function()
-      ro.setup()
       assert.is_table(autocmd_callbacks[2].opts.pattern)
-      assert.is_string(autocmd_callbacks[2].opts.pattern[1])
-    end)
-  end)
-
-  describe("extmark storage", function()
-    it("should initialize extmark table", function()
-      assert.is_table(ro.extmark)
+      assert.is_table(autocmd_callbacks[3].opts.pattern)
     end)
 
-    it("should store options from config after setup", function()
+    it("skips setup when read_only is disabled", function()
+      mock_config({
+        enabled = false,
+        region_text = {
+          start = "begin read only",
+          ending = "end read only",
+        },
+      })
+
       ro.setup()
-      assert.is_equal("begin read only", ro.opt.region_text.start)
-      assert.is_equal("end read only", ro.opt.region_text.ending)
-    end)
-  end)
 
-  describe("namespace and augroup", function()
-    it("should have valid namespace, augroup, and highlight group", function()
-      assert.is_equal("test", ro.namespace)
-      assert.is_equal("autest", ro.ro_group)
-      assert.is_equal("hl_ro", ro.hl_group)
-    end)
-  end)
-
-  describe("error handling", function()
-    it("should handle empty options", function()
-      assert.has_no_error(function()
-        ro.setup()
-      end)
+      assert.equals(0, #autocmd_callbacks)
     end)
 
-    it("should handle multiple setups with different configs", function()
+    it("updates options on subsequent setups", function()
       ro.setup()
-      -- Update config to different values
       mock_config({
         enabled = true,
         region_text = { start = "start", ending = "finish" },
       })
-      ro.setup()
-      assert.is_equal("start", ro.opt.region_text.start)
-    end)
-  end)
 
-  describe("callback execution", function()
-    it("should invoke ColorScheme callback", function()
       ro.setup()
-      local colorscheme_callback = autocmd_callbacks[1].opts.callback
-      assert.is_not_nil(colorscheme_callback)
-      assert.has_no_error(function()
-        colorscheme_callback()
-      end)
+
+      assert.equals("start", ro.opt.region_text.start)
+      assert.equals("finish", ro.opt.region_text.ending)
     end)
 
-    it("should invoke BufReadPost callback", function()
-      ro.setup()
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-      assert.is_not_nil(bufread_callback)
-      assert.has_no_error(function()
-        bufread_callback()
-      end)
-    end)
-
-    it("should call highlight.set_highlight on ColorScheme event", function()
+    it("ColorScheme callback applies highlight", function()
       ro.setup()
       local hl = require("gnattest.highlight")
-      local colorscheme_callback = autocmd_callbacks[1].opts.callback
+      local colorscheme_callback = get_callback(1)
+
       colorscheme_callback()
+
       assert.stub(hl.set_highlight).was_called()
     end)
+  end)
 
-    it("should call notify when protected region is changed", function()
+  describe("callbacks", function()
+    before_each(function()
       ro.setup()
+    end)
+
+    it("BufReadPost refreshes extmarks", function()
+      local bufread_callback = get_callback(2)
+
+      bufread_callback()
+
+      assert.stub(_G.vim.api.nvim_buf_set_extmark).was_called()
+      assert.is_not_nil(ro.backup)
+    end)
+
+    it("TextChanged protects modified lines and skips diff mode", function()
       local utils = require("gnattest.utils")
-      assert.is_not_nil(utils.notify)
-    end)
-  end)
+      local bufread_callback = get_callback(2)
+      bufread_callback()
 
-  describe("region marker recognition", function()
-    it("should accept custom start marker", function()
-      mock_config({
-        enabled = true,
-        region_text = { start = "LOCK", ending = "UNLOCK" },
-      })
-      ro.setup()
-      assert.is_equal("LOCK", ro.opt.region_text.start)
-    end)
-
-    it("should accept custom end marker", function()
-      mock_config({
-        enabled = true,
-        region_text = { start = "LOCK", ending = "UNLOCK" },
-      })
-      ro.setup()
-      assert.is_equal("UNLOCK", ro.opt.region_text.ending)
-    end)
-
-    it("should handle default markers", function()
-      ro.setup()
-      assert.is_equal("begin read only", ro.opt.region_text.start)
-    end)
-  end)
-
-  describe("diff mode detection", function()
-    it("should handle diff mode states correctly", function()
-      ro.setup()
-
-      -- Default diff mode should be false
-      assert.is_false(_G.vim.opt.diff:get())
-
-      -- Should detect when diff mode is enabled
-      _G.vim.opt.diff.get = function()
-        return true
-      end
-      assert.is_true(_G.vim.opt.diff:get())
-
-      -- Should detect when diff mode is disabled
       _G.vim.opt.diff.get = function()
         return false
       end
-      assert.is_false(_G.vim.opt.diff:get())
-    end)
-  end)
-
-  describe("highlight integration", function()
-    it("should set hl_group on highlight namespace", function()
-      ro.setup()
-      assert.is_equal("hl_ro", ro.hl_group)
-    end)
-
-    it("should call set_highlight on ColorScheme event", function()
-      ro.setup()
-      local hl = require("gnattest.highlight")
-      local colorscheme_cb = autocmd_callbacks[1].opts.callback
-      colorscheme_cb()
-      assert.stub(hl.set_highlight).was_called()
-    end)
-  end)
-
-  describe("extmark data structure", function()
-    it("should store line data in extmark table", function()
-      ro.setup()
-      assert.is_table(ro.extmark)
-    end)
-
-    it("should preserve extmark across operations", function()
-      ro.setup()
-
-      ro.setup()
-      -- Extmark table should be preserved (same reference or new table)
-      assert.is_table(ro.extmark)
-    end)
-  end)
-
-  describe("region detection", function()
-    it("should get comments from utils", function()
-      ro.setup()
-      local utils = require("gnattest.utils")
-      local comments = utils.get_all_comments()
-      assert.is_table(comments)
-      assert.is_equal(2, #comments)
-    end)
-
-    it("should parse region markers from comments", function()
-      ro.setup()
-      local utils = require("gnattest.utils")
-      local comments = utils.get_all_comments()
-      assert.is_equal("--begin read only", comments[1].text)
-      assert.is_equal("--end read only", comments[2].text)
-    end)
-  end)
-
-  describe("state consistency", function()
-    it("should maintain consistent state after setup operations", function()
-      ro.setup()
-      assert.is_not_nil(ro.namespace)
-      assert.is_not_nil(ro.ro_group)
-      assert.is_not_nil(ro.hl_group)
-      assert.is_table(ro.extmark)
-
-      -- Namespace and augroup should remain stable across setups
-      local ns_before = ro.namespace
-      local group_before = ro.ro_group
-      ro.setup()
-      ro.setup()
-
-      assert.is_equal(ns_before, ro.namespace)
-      assert.is_equal(group_before, ro.ro_group)
-    end)
-  end)
-
-  describe("vim API integration", function()
-    it("should use required vim API functions and log levels", function()
-      ro.setup()
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-      bufread_callback()
-
-      assert.stub(_G.vim.api.nvim_create_autocmd).was_called()
-      assert.stub(_G.vim.api.nvim_buf_set_extmark).was_called()
-      assert.is_not_nil(_G.vim.api.nvim_buf_set_lines)
-      assert.is_not_nil(_G.vim.log.levels.ERROR)
-    end)
-  end)
-
-  describe("pattern configuration", function()
-    it("should use correct gnattest patterns for file matching", function()
-      ro.setup()
-      local utils = require("gnattest.utils")
-
-      assert.is_table(utils.gnattest_pattern)
-    end)
-  end)
-
-  describe("comment parsing edge cases", function()
-    it("should handle comments with and without region markers", function()
-      ro.setup()
-      local utils = require("gnattest.utils")
-      local comments = utils.get_all_comments()
-      assert.is_table(comments)
-      assert.is_not_nil(comments)
-    end)
-  end)
-
-  describe("region protection notifications", function()
-    it("should use notification system with ERROR log level", function()
-      ro.setup()
-      local utils = require("gnattest.utils")
-      assert.is_not_nil(utils.notify)
-      assert.is_equal(4, _G.vim.log.levels.ERROR)
-    end)
-  end)
-
-  describe("fix_ro_regions logic", function()
-    it("should have required vim APIs for region processing", function()
-      ro.setup()
-
-      assert.is_not_nil(_G.vim.schedule)
-      assert.is_not_nil(_G.vim.api.nvim_buf_get_extmarks)
-
-      local pos = _G.vim.fn.getpos(".")
-      assert.is_table(pos)
-      assert.is_equal(5, pos[2])
-    end)
-  end)
-
-  describe("protection workflow mechanisms", function()
-    it(
-      "should handle backup, change detection, protection, and mark restoration",
-      function()
-        ro.setup()
-
-        -- Backup mechanism: Trigger BufReadPost to create backup
-        local bufread_callback = autocmd_callbacks[2].opts.callback
-        bufread_callback()
-        assert.is_true(true) -- Verify no error occurs
-
-        -- Change detection: Compare buffer content with stored lines
-        local utils = require("gnattest.utils")
-        local lines = utils.get_lines(1, 2)
-        assert.is_equal(2, #lines)
-        assert.is_not_nil(_G.vim.api.nvim_buf_set_lines)
-
-        -- TextChanged protection mechanism
-        local text_changed_callback = autocmd_callbacks[3].opts.callback
-        assert.is_not_nil(text_changed_callback)
-        assert.is_not_nil(_G.vim.schedule)
-
-        -- Mark restoration
-        assert.is_not_nil(_G.vim.api.nvim_win_set_cursor)
-        assert.stub(_G.vim.api.nvim_buf_set_extmark).was_called()
+      _G.vim.deep_equal = function()
+        return false
       end
-    )
-  end)
-
-  describe("full workflow simulation", function()
-    it("should handle BufReadPost callback operations correctly", function()
-      ro.setup()
-
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-
-      -- Should handle single BufReadPost without error
-      assert.has_no_error(function()
-        bufread_callback()
-      end)
-      assert.stub(_G.vim.api.nvim_buf_set_extmark).was_called()
-
-      -- Should handle multiple BufReadPost events without error
-      assert.has_no_error(function()
-        bufread_callback()
-      end)
-    end)
-  end)
-
-  describe("configuration persistence", function()
-    it("should maintain and update options correctly", function()
-      mock_config({
-        enabled = true,
-        region_text = { start = "TEST_START", ending = "TEST_END" },
-      })
-      ro.setup()
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-      bufread_callback()
-      assert.is_equal("TEST_START", ro.opt.region_text.start)
-
-      mock_config({
-        enabled = true,
-        region_text = { start = "NEW", ending = "NEW_END" },
-      })
-      ro.setup()
-      assert.is_equal("NEW", ro.opt.region_text.start)
-    end)
-  end)
-
-  describe("region modification detection and protection", function()
-    it("should handle region protection scenarios correctly", function()
-      ro.setup()
-      local utils = require("gnattest.utils")
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-      bufread_callback()
-
-      -- Verify extmark was populated
-      assert.is_not_nil(ro.extmark[42])
-
       _G.vim.api.nvim_buf_get_extmarks = stub.new().returns({
         { 42, 1, 0, { end_row = 2 } },
       })
-      _G.vim.schedule = function(cb)
-        cb()
-      end
-      local text_changed_callback = autocmd_callbacks[3].opts.callback
-
-      -- Test 1: Should trigger protection when lines are modified
-      _G.vim.deep_equal = function()
-        return false
-      end
       _G.vim.api.nvim_buf_get_lines =
         stub.new().returns({ "modified_A", "modified_B" })
+
+      local text_changed_callback = get_callback(3)
       text_changed_callback()
+
       assert.stub(utils.notify).was_called()
 
-      -- Test 2: Should not trigger protection when lines are unchanged
-      _G.vim.deep_equal = function()
-        return true
-      end
-      _G.vim.api.nvim_buf_get_lines = stub.new().returns({ "lineA", "lineB" })
-      local notify_count_before = #utils.notify.calls
-      text_changed_callback()
-      local notify_count_after = #utils.notify.calls
-      assert.is_equal(notify_count_before, notify_count_after)
-
-      -- Test 3: Should skip processing when in diff mode
       _G.vim.opt.diff.get = function()
         return true
       end
@@ -540,41 +246,154 @@ describe("gnattest.read_only", function()
       _G.vim.schedule = function()
         schedule_called = true
       end
+
       text_changed_callback()
+
       assert.is_false(schedule_called)
     end)
 
-    it("exercises extmarks with details and overlap options", function()
-      ro.setup()
+    it("uses protect_flag to refresh only once", function()
+      local bufread_callback = get_callback(2)
+      bufread_callback()
+
       _G.vim.opt.diff.get = function()
         return false
       end
-
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-      bufread_callback()
-
-      -- This should trigger the specific get_extmarks call with details/overlap
-      local text_changed_callback = autocmd_callbacks[3].opts.callback
-      text_changed_callback()
-
-      assert.is_true(true) -- Test completed without error
-    end)
-
-    it("uses extmarks with details and overlap options", function()
-      ro.setup()
-      local bufread_callback = autocmd_callbacks[2].opts.callback
-      bufread_callback()
-
-      _G.vim.opt.diff.get = function()
+      _G.vim.deep_equal = function()
         return false
       end
       local get_extmarks_spy = stub(_G.vim.api, "nvim_buf_get_extmarks")
       get_extmarks_spy.returns({ { 42, 1, 0, { end_row = 2 } } })
 
-      local text_changed_callback = autocmd_callbacks[3].opts.callback
+      local text_changed_callback = get_callback(3)
+      text_changed_callback()
+      local call_count = #get_extmarks_spy.calls
+
       text_changed_callback()
 
-      assert.stub(get_extmarks_spy).was_called()
+      assert.equals(call_count, #get_extmarks_spy.calls)
+    end)
+
+    it("returns early when diff mode enabled", function()
+      ro.setup()
+      _G.vim.opt.diff.get = function()
+        return true
+      end
+
+      get_callback(3)()
+    end)
+  end)
+
+  describe("conform workaround", function()
+    it("skips conform workaround when read_only is disabled", function()
+      autocmd_callbacks = {}
+      local config = require("gnattest.config")
+      local calls = 0
+      config.get = function()
+        calls = calls + 1
+        if calls == 1 then
+          return { read_only = { enabled = true } }
+        end
+        return { read_only = { enabled = false } }
+      end
+
+      ro.setup()
+
+      assert.equals(3, #autocmd_callbacks)
+    end)
+
+    it("disables read_only during ConformFormatPre", function()
+      ro.setup()
+      local config = require("gnattest.config")
+      local pre_callback = get_callback(4)
+
+      pre_callback()
+
+      assert
+        .stub(config.set)
+        .was_called_with({ read_only = { enabled = false } })
+    end)
+
+    it("re-enables read_only during ConformFormatPost", function()
+      ro.setup()
+      local config = require("gnattest.config")
+      local post_callback = get_callback(5)
+      local schedule_spy = stub.new().invokes(function(cb)
+        cb()
+      end)
+      _G.vim.schedule = schedule_spy
+
+      post_callback()
+
+      assert
+        .stub(config.set)
+        .was_called_with({ read_only = { enabled = true } })
+      assert.stub(schedule_spy).was_called()
+    end)
+
+    it("skips ConformFormatPost when read_only disabled", function()
+      ro.setup()
+      local config = require("gnattest.config")
+      local pre_callback = get_callback(4)
+      local post_callback = get_callback(5)
+      local schedule_spy = stub.new()
+      _G.vim.schedule = schedule_spy
+
+      config.get = function()
+        return { read_only = { enabled = false } }
+      end
+
+      pre_callback()
+      local set_count_before = #config.set.calls
+      post_callback()
+
+      assert.equals(set_count_before, #config.set.calls)
+      assert.stub(schedule_spy).was_not_called()
+    end)
+  end)
+
+  describe("refresh and reset", function()
+    it("refresh clears state when read_only is disabled", function()
+      ro.setup()
+      ro.extmark[42] = { lines = { "lineA" } }
+
+      local config = require("gnattest.config")
+      config.get = function()
+        return { read_only = { enabled = false } }
+      end
+
+      local bufread_callback = get_callback(2)
+      bufread_callback()
+
+      assert.stub(_G.vim.api.nvim_buf_clear_namespace).was_called()
+      assert.is_nil(ro.backup)
+      assert.is_true(next(ro.extmark) == nil)
+    end)
+
+    it("refresh clears namespace with end_row -1", function()
+      ro.setup()
+      ro.extmark[42] = { lines = { "lineA" } }
+      local config = require("gnattest.config")
+      config.get = function()
+        return { read_only = { enabled = false } }
+      end
+
+      local bufread_callback = get_callback(2)
+      bufread_callback()
+
+      assert
+        .stub(_G.vim.api.nvim_buf_clear_namespace)
+        .was_called_with(1, ro.namespace, 1, -1)
+    end)
+
+    it("reset clears and reinitializes state", function()
+      ro.setup()
+      ro.extmark[1] = { lines = { "lineA" } }
+
+      ro.reset()
+
+      assert.stub(_G.vim.api.nvim_buf_clear_namespace).was_called()
+      assert.is_table(ro.extmark)
     end)
   end)
 
@@ -611,35 +430,99 @@ describe("gnattest.read_only", function()
         assert.is_nil(result)
       end)
 
+      it("_get_regions creates backup and invokes callback", function()
+        ro.setup()
+        local bufread_callback = get_callback(2)
+        bufread_callback()
+
+        ro.backup = nil
+        local cb_calls = {}
+
+        ro._get_regions(function(start_line, end_line, index)
+          table.insert(cb_calls, { start_line, end_line, index })
+        end)
+
+        assert.is_not_nil(ro.backup)
+        assert.is_equal(1, #cb_calls)
+        assert.is_equal(1, cb_calls[1][1])
+        assert.is_equal(2, cb_calls[1][2])
+        assert.is_equal(1, cb_calls[1][3])
+      end)
+
+      it("_set_extmark updates an existing mark id", function()
+        ro._set_extmark(1, 2, 0)
+        ro._set_extmark(1, 2, 99)
+
+        local last_call =
+          _G.vim.api.nvim_buf_set_extmark.calls[#_G.vim.api.nvim_buf_set_extmark.calls]
+        assert.is_table(last_call)
+        assert.is_table(last_call.vals)
+        assert.is_table(last_call.vals[5])
+        assert.is_equal(99, last_call.vals[5].id)
+      end)
+
+      it("_fix_ro_regions restores modified lines", function()
+        ro.setup()
+        local bufread_callback = get_callback(2)
+        bufread_callback()
+
+        _G.vim.opt.diff.get = function()
+          return false
+        end
+        _G.vim.deep_equal = function()
+          return false
+        end
+        _G.vim.api.nvim_buf_get_extmarks = stub.new().returns({
+          { 42, 1, 0, { end_row = 2 } },
+        })
+        _G.vim.api.nvim_buf_get_lines = stub.new().returns({ "changed" })
+
+        ro._fix_ro_regions()
+
+        assert.stub(_G.vim.api.nvim_buf_set_lines).was_called()
+        assert.stub(_G.vim.api.nvim_win_set_cursor).was_called()
+        assert.stub(_G.vim.cmd).was_called_with([[stopinsert]])
+      end)
+
+      it("_fix_ro_regions clears state when read_only disabled", function()
+        ro.setup()
+        local bufread_callback = get_callback(2)
+        bufread_callback()
+
+        local config = require("gnattest.config")
+        config.get = function()
+          return { read_only = { enabled = false } }
+        end
+
+        ro._fix_ro_regions()
+
+        assert.stub(_G.vim.api.nvim_buf_clear_namespace).was_called()
+      end)
+
       it(
-        "_fix_ro_regions calls vim.api.nvim_buf_get_extmarks with details and overlap",
+        "_fix_ro_regions calls get_extmarks with details and overlap",
         function()
           ro.setup()
-          local bufread_callback = autocmd_callbacks[2].opts.callback
+          local bufread_callback = get_callback(2)
           bufread_callback()
 
-          -- Verify extmark was populated
-          assert.is_not_nil(ro.extmark[42])
-
-          -- Ensure diff mode is off (required for fix_ro_regions to execute)
           _G.vim.opt.diff.get = function()
             return false
           end
 
-          -- Track the arguments passed to nvim_buf_get_extmarks
           local get_extmarks_args = nil
           _G.vim.api.nvim_buf_get_extmarks = stub.new().invokes(function(...)
             get_extmarks_args = { ... }
             return {}
           end)
 
-          -- Call _fix_ro_regions directly
           ro._fix_ro_regions()
 
-          -- Verify get_extmarks was called with correct parameters
           assert.stub(_G.vim.api.nvim_buf_get_extmarks).was_called()
-          -- The last argument should be the options table with details and overlap
           assert.is_not_nil(get_extmarks_args)
+          assert.is_table(get_extmarks_args[5])
+          assert.is_true(get_extmarks_args[5].details)
+          assert.is_true(get_extmarks_args[5].overlap)
         end
       )
     end)

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -14,9 +14,7 @@ describe("gnattest.utils", function()
       nvim_get_current_buf = function()
         return 0
       end,
-      nvim_buf_get_lines = function()
-        return { "line1", "line2" }
-      end,
+      nvim_buf_get_lines = stub.new().returns({ "line1", "line2" }),
       nvim__get_runtime = function()
         return {}
       end,
@@ -130,8 +128,9 @@ describe("gnattest.utils", function()
     assert.is_true(utils.is_gnattest_file())
   end)
 
-  it("returns lines from get_lines", function()
+  it("returns lines from get_lines using current buffer", function()
     assert.are.same({ "line1", "line2" }, utils.get_lines(0, 1))
+    assert.stub(_G.vim.api.nvim_buf_get_lines).was_called_with(0, 0, 2, true)
   end)
 
   it("returns comments via get_all_comments", function()
@@ -140,36 +139,70 @@ describe("gnattest.utils", function()
     assert.same("--begin read only", comments[1].text)
   end)
 
-  it("handles missing ada treesitter parser gracefully", function()
-    _G.vim.treesitter.get_parser = function(_, lang)
-      if lang == "ada" then
-        return nil
-      end
-      error("No parser")
-    end
-    utils = require("gnattest.utils")
+  it("returns empty table for invalid treesitter states", function()
+    local cases = {
+      {
+        name = "get_node_text errors",
+        apply = function()
+          _G.vim.treesitter.get_node_text = function()
+            error("text error")
+          end
+        end,
+      },
+      {
+        name = "get_node_text empty",
+        apply = function()
+          _G.vim.treesitter.get_node_text = function()
+            return ""
+          end
+        end,
+      },
+      {
+        name = "missing ada parser",
+        apply = function()
+          _G.vim.treesitter.get_parser = function(_, lang)
+            if lang == "ada" then
+              return nil
+            end
+            error("No parser")
+          end
+          utils = require("gnattest.utils")
+        end,
+      },
+      {
+        name = "query parse failure",
+        apply = function()
+          _G.vim.treesitter.query.parse = function()
+            return nil
+          end
+          utils = require("gnattest.utils")
+        end,
+      },
+      {
+        name = "parser pcall failure",
+        apply = function()
+          _G.vim.treesitter.get_parser = function()
+            error("Parser error")
+          end
+          utils = require("gnattest.utils")
+        end,
+      },
+    }
 
-    local comments = utils.get_all_comments("ada")
-    assert.same({}, comments)
+    for _, case in ipairs(cases) do
+      case.apply()
+      local comments = utils.get_all_comments("ada")
+      assert.same({}, comments)
+    end
   end)
 
-  it("handles treesitter query parse failure gracefully", function()
+  it("returns empty table when query.parse errors", function()
     _G.vim.treesitter.query.parse = function()
-      return nil
+      error("query parse error")
     end
-    utils = require("gnattest.utils")
 
     local comments = utils.get_all_comments("ada")
-    assert.same({}, comments)
-  end)
 
-  it("handles failed parser pcall", function()
-    _G.vim.treesitter.get_parser = function()
-      error("Parser error")
-    end
-    utils = require("gnattest.utils")
-
-    local comments = utils.get_all_comments("ada")
     assert.same({}, comments)
   end)
 

--- a/spec/xml_spec.lua
+++ b/spec/xml_spec.lua
@@ -65,6 +65,40 @@ local stub_vim_api = function()
   end
 end
 
+-- Simplified XML parsing mock setup
+local function setup_xml_parsing_mocks(
+  unit_captures,
+  pkg_captures,
+  test_captures,
+  node_text_mapping
+)
+  _G.vim.treesitter.query.parse = function(_, query_str)
+    return {
+      captures = query_str:find("test_unit") and { "target_file" }
+        or query_str:find("unit") and { "source_file" }
+        or { "src", "tst" },
+      iter_captures = function()
+        local captures = query_str:find("test_unit") and (pkg_captures or {})
+          or query_str:find("unit") and (unit_captures or {})
+          or (test_captures or {})
+        local idx = 0
+        return function()
+          idx = idx + 1
+          if idx <= #captures then
+            return captures[idx].id, captures[idx].node
+          end
+        end
+      end,
+    }
+  end
+  _G.vim.treesitter.get_node_text = function(node)
+    return (node_text_mapping and node_text_mapping[node]) or tostring(node)
+  end
+  _G.vim.fn.readfile = function()
+    return { "<tests_mapping></tests_mapping>" }
+  end
+end
+
 describe("gnattest.xml", function()
   before_each(function()
     stub_vim_api()
@@ -139,12 +173,45 @@ describe("gnattest.xml", function()
       local result = xml.get_xml_info()
       assert.is_table(result)
     end)
+
+    it("refresh bypasses cache", function()
+      local parse_calls = 0
+      _G.vim.treesitter.get_parser = function()
+        parse_calls = parse_calls + 1
+        return {
+          parse = function()
+            return {
+              {
+                root = function()
+                  return "root"
+                end,
+              },
+            }
+          end,
+        }
+      end
+
+      setup_xml_parsing_mocks(
+        { { id = 1, node = "unit_flag" }, { id = 1, node = "unit_file" } },
+        {},
+        {},
+        { unit_flag = "source_file", unit_file = "my_file.ads" }
+      )
+
+      xml.get_xml_info()
+      xml.get_xml_info()
+      xml.get_xml_info(true)
+
+      assert.equals(2, parse_calls)
+    end)
   end)
 
   describe("real fixture parsing", function()
-    it("validates fixture file XML structure and content", function()
-      local fixture_path = "spec/fixtures/gnattest.xml"
-      local xml_lines = {}
+    local fixture_path = "spec/fixtures/gnattest.xml"
+    local xml_lines
+
+    before_each(function()
+      xml_lines = {}
       local file = io.open(fixture_path, "r")
       assert.is_not_nil(file)
       if file then
@@ -153,7 +220,9 @@ describe("gnattest.xml", function()
         end
         file:close()
       end
+    end)
 
+    it("validates fixture file XML structure and content", function()
       assert.is_true(#xml_lines > 0)
       local content = table.concat(xml_lines, "\n")
 
@@ -267,40 +336,6 @@ describe("gnattest.xml", function()
     end)
   end)
 
-  -- Simplified XML parsing mock setup
-  local function setup_xml_parsing_mocks(
-    unit_captures,
-    pkg_captures,
-    test_captures,
-    node_text_mapping
-  )
-    _G.vim.treesitter.query.parse = function(_, query_str)
-      return {
-        captures = query_str:find("test_unit") and { "target_file" }
-          or query_str:find("unit") and { "source_file" }
-          or { "src", "tst" },
-        iter_captures = function()
-          local captures = query_str:find("test_unit") and (pkg_captures or {})
-            or query_str:find("unit") and (unit_captures or {})
-            or (test_captures or {})
-          local idx = 0
-          return function()
-            idx = idx + 1
-            if idx <= #captures then
-              return captures[idx].id, captures[idx].node
-            end
-          end
-        end,
-      }
-    end
-    _G.vim.treesitter.get_node_text = function(node)
-      return (node_text_mapping and node_text_mapping[node]) or tostring(node)
-    end
-    _G.vim.fn.readfile = function()
-      return { "<tests_mapping></tests_mapping>" }
-    end
-  end
-
   describe("XML parsing logic coverage tests", function()
     describe("core data structure population", function()
       it("populates source_files table from unit captures", function()
@@ -394,18 +429,18 @@ describe("gnattest.xml", function()
         assert.equals("file1", filename)
       end)
 
-      it("returns nil if test name not present", function()
-        xml = inject_xml_data({
-          file1 = { pkg1 = { { source = { name = "testA" }, test = {} } } },
-        })
-        assert.is_nil(xml.get_test_by_name("pkg1", "missing"))
-      end)
+      it("returns nil when package or name missing", function()
+        local cases = {
+          { pkg = "pkg1", name = "missing" },
+          { pkg = "missing_pkg", name = "testA" },
+        }
 
-      it("returns nil if package not present", function()
-        xml = inject_xml_data({
-          file1 = { pkg1 = { { source = { name = "testA" }, test = {} } } },
-        })
-        assert.is_nil(xml.get_test_by_name("missing_pkg", "testA"))
+        for _, case in ipairs(cases) do
+          xml = inject_xml_data({
+            file1 = { pkg1 = { { source = { name = "testA" }, test = {} } } },
+          })
+          assert.is_nil(xml.get_test_by_name(case.pkg, case.name))
+        end
       end)
 
       it("handles multiple tests and packages", function()
@@ -505,6 +540,38 @@ describe("gnattest.xml", function()
         assert.equals("my_package.ads", file)
         assert.equals("Package1", pkg)
         assert.equals("My_Function", info.source.name)
+      end)
+
+      it("populates xml_info when empty", function()
+        for k in pairs(xml._xml_info) do
+          xml._xml_info[k] = nil
+        end
+
+        local parse_calls = 0
+        _G.vim.treesitter.get_parser = function()
+          parse_calls = parse_calls + 1
+          return {
+            parse = function()
+              return {
+                {
+                  root = function()
+                    return "root"
+                  end,
+                },
+              }
+            end,
+          }
+        end
+
+        setup_xml_parsing_mocks(
+          { { id = 1, node = "unit_flag" }, { id = 1, node = "unit_file" } },
+          {},
+          {},
+          { unit_flag = "source_file", unit_file = "my_file.ads" }
+        )
+
+        assert.is_nil(xml.get_test_from_src_file_line("my_package.ads", 10))
+        assert.equals(1, parse_calls)
       end)
 
       it("returns nil when no match", function()
@@ -627,6 +694,26 @@ describe("gnattest.xml", function()
         assert.equals("Package1", pkg)
         assert.equals("Test_My_Function", info.test.name)
       end)
+
+      it("returns nil when no matches", function()
+        xml = inject_xml_data({
+          ["my_package.ads"] = {
+            Package1 = {
+              {
+                source = { name = "Other_Function", line = "10", column = "2" },
+                test = {
+                  name = "Test_Other_Function",
+                  file = "test_file.adb",
+                  line = "20",
+                  column = "4",
+                },
+              },
+            },
+          },
+        })
+
+        assert.is_nil(xml.get_gnattest_info_on_line(99))
+      end)
     end)
 
     describe("get_gnattest_info_on_cursor", function()
@@ -701,16 +788,16 @@ describe("gnattest.xml", function()
       end)
     end)
 
-    describe("xml_info internal state tests", function()
-      local function set_xml_info(data)
-        for k in pairs(xml._xml_info) do
-          xml._xml_info[k] = nil
-        end
-        for k, v in pairs(data) do
-          xml._xml_info[k] = v
-        end
+    local function set_xml_info(data)
+      for k in pairs(xml._xml_info) do
+        xml._xml_info[k] = nil
       end
+      for k, v in pairs(data) do
+        xml._xml_info[k] = v
+      end
+    end
 
+    describe("xml_info internal state tests", function()
       it("get_xml_info returns cached results on second call", function()
         set_xml_info({
           ["src/my_package.ads"] = {
@@ -722,6 +809,43 @@ describe("gnattest.xml", function()
         local result1 = xml.get_xml_info()
         local result2 = xml.get_xml_info()
         assert.equals(result1, result2)
+      end)
+
+      it("get_xml_info refreshes when requested", function()
+        set_xml_info({
+          ["src/my_package.ads"] = {
+            ["gnattest_prefix_my_package.ads"] = {
+              { name = "test_add", line = 50 },
+            },
+          },
+        })
+
+        local parse_calls = 0
+        _G.vim.treesitter.get_parser = function()
+          parse_calls = parse_calls + 1
+          return {
+            parse = function()
+              return {
+                {
+                  root = function()
+                    return "root"
+                  end,
+                },
+              }
+            end,
+          }
+        end
+
+        setup_xml_parsing_mocks(
+          { { id = 1, node = "unit_flag" }, { id = 1, node = "unit_file" } },
+          {},
+          {},
+          { unit_flag = "source_file", unit_file = "my_file.ads" }
+        )
+
+        xml.get_xml_info(true)
+
+        assert.equals(1, parse_calls)
       end)
 
       it("structure contains source files and test packages", function()
@@ -762,15 +886,6 @@ describe("gnattest.xml", function()
     end)
 
     describe("xml_info structure validation", function()
-      local function set_xml_info(data)
-        for k in pairs(xml._xml_info) do
-          xml._xml_info[k] = nil
-        end
-        for k, v in pairs(data) do
-          xml._xml_info[k] = v
-        end
-      end
-
       it("src_info contains name, line, column, and test fields", function()
         set_xml_info({
           ["src/my_package.ads"] = {


### PR DESCRIPTION
- Refresh read-only state when test buffers are reopened after regenerate
- Disable/re-enable read-only around `:Gnattest generate` and refresh XML cache
- Update read-only, utils, and XML tests for the new refresh behavior


Fixes #19