### PR TITLE
Add test case support for GNATtest

### DIFF
--- a/lua/gnattest/navigation.lua
+++ b/lua/gnattest/navigation.lua
@@ -49,9 +49,9 @@ function M.switch_subprogram()
     column = tonumber(info.source.column)
     als.switch_to_source()
   else
-    file = als.get_tests_dir() .. "/" .. info.test.file
-    line = tonumber(info.test.line)
-    column = tonumber(info.test.column)
+    file = als.get_tests_dir() .. "/" .. info.tests[1].file
+    line = tonumber(info.tests[1].line)
+    column = tonumber(info.tests[1].column)
     als.switch_to_tests()
   end
 

--- a/lua/gnattest/picker.lua
+++ b/lua/gnattest/picker.lua
@@ -33,8 +33,8 @@ function M.select_tests()
           display = pkg .. ":" .. info.source.name,
           ordinal = pkg .. ":" .. info.source.name,
           filename = source_file,
-          path = (test_dir or ".") .. "/" .. info.test.file,
-          lnum = tonumber(info.test.line) + 5, -- Adjust line number to point to the test body
+          path = (test_dir or ".") .. "/" .. info.tests[1].file,
+          lnum = tonumber(info.tests[1].line) + 5, -- Adjust line number to point to the test body
           source_line = info.source.line,
         })
       end

--- a/lua/gnattest/read_only.lua
+++ b/lua/gnattest/read_only.lua
@@ -240,6 +240,7 @@ function M.setup()
 
   vim.api.nvim_create_autocmd("ColorScheme", {
     group = M.ro_group,
+    pattern = gnattest_pattern,
     callback = function()
       require("gnattest.highlight").set_highlight(M.namespace, M.hl_group)
     end,

--- a/lua/gnattest/runner.lua
+++ b/lua/gnattest/runner.lua
@@ -14,12 +14,12 @@ end
 local function prepare_qf_item(pkg, test_info, line, type)
   local utils = require("gnattest.utils")
   local test_dir = require("gnattest.ada_ls").get_tests_dir()
-  local lnum = tonumber(test_info.test.line)
-  local col = tonumber(test_info.test.column)
-  local file = utils.find_file(test_info.test.file, test_dir)
+  local lnum = tonumber(test_info.tests.line)
+  local col = tonumber(test_info.tests.column)
+  local file = utils.find_file(test_info.tests.file, test_dir)
 
   if not file then
-    file = test_info.test.file
+    file = test_info.tests.file
     utils.notify(
       file .. " not found in " .. test_dir .. " directory",
       vim.log.levels.WARN

--- a/lua/gnattest/runner.lua
+++ b/lua/gnattest/runner.lua
@@ -74,7 +74,7 @@ local function on_exit_tests(obj)
 
     for _, line in ipairs(lines) do
       local _, pkg, test_info =
-        require("gnattest.xml").get_test_from_src_file_line(
+        require("gnattest.xml").get_test_from_src_case_line(
           vim.split(line, ":")[1], -- filename
           tonumber(vim.split(line, ":")[2]) -- line number
         )

--- a/lua/gnattest/utils.lua
+++ b/lua/gnattest/utils.lua
@@ -79,8 +79,8 @@ function M.is_gnattest_file()
 
   local bufdir = M.get_bufdir()
   local result = string.find(bufdir, "gnattest") ~= nil
-    or string.find(bufdir, als.get_harness_dir()) ~= nil
-    or string.find(bufdir, als.get_tests_dir()) ~= nil
+    or string.find(als.get_harness_dir(), bufdir) ~= nil
+    or string.find(als.get_tests_dir(), bufdir) ~= nil
   gnattest_file_cache[bufid] = result
   return result
 end

--- a/lua/gnattest/xml.lua
+++ b/lua/gnattest/xml.lua
@@ -286,8 +286,8 @@ function M.get_gnattest_info_on_line(lnum)
           for _, test in ipairs(info.tests) do
             if
               vim.fn.match(test.file, filename) == 0
-              and start_line <= lnum
-              and end_line >= lnum
+              and start_line <= tonumber(test.line)
+              and end_line >= tonumber(test.line)
             then
               return f, p, info
             end

--- a/lua/gnattest/xml.lua
+++ b/lua/gnattest/xml.lua
@@ -103,6 +103,7 @@ function M.get_xml_info(refresh)
   local test_capture_flag = ""
   local gnattest_info = {}
   local src_info = {}
+  local test_cases = {}
   local test_info = {}
   local test_query = query_test_info()
 
@@ -121,10 +122,16 @@ function M.get_xml_info(refresh)
             src_info.name = test_text
           elseif test_capture_flag == "column" then
             src_info.column = test_text
+          elseif test_capture_flag == "line" then
+            src_info.line = test_text
           end
         elseif capture_id == "t_src" then
-          if test_capture_flag == "line" then
-            src_info.line = test_text
+          if test_capture_flag == "name" then
+            test_cases.name = test_text
+          elseif test_capture_flag == "line" then
+            test_cases.line = test_text
+          elseif test_capture_flag == "column" then
+            test_cases.column = test_text
           end
         elseif capture_id == "tst" then
           if test_capture_flag == "file" then
@@ -136,10 +143,12 @@ function M.get_xml_info(refresh)
           elseif test_capture_flag == "name" then
             test_info.name = test_text
             gnattest_info.source = src_info
+            gnattest_info.source.case = test_cases
             gnattest_info.test = test_info
             table.insert(pkg_info, gnattest_info)
             src_info = {}
             gnattest_info = {}
+            test_cases = {}
             test_info = {}
           end
         end
@@ -183,7 +192,7 @@ function M.get_pkg_tests(pkg)
   return nil
 end
 
-function M.get_test_from_src_file_line(filename, line)
+function M.get_test_from_src_case_line(filename, line)
   if next(xml_info) == nil then
     M.get_xml_info()
   end
@@ -191,7 +200,7 @@ function M.get_test_from_src_file_line(filename, line)
   for f, files in pairs(xml_info) do
     for p, pkg_info in pairs(files) do
       for _, test_info in pairs(pkg_info) do
-        if f == filename and tonumber(test_info.source.line) == line then
+        if f == filename and tonumber(test_info.source.case.line) == line then
           return f, p, test_info
         end
       end
@@ -228,9 +237,19 @@ function M.get_gnattest_info_on_line(lnum)
   local utils = require("gnattest.utils")
   local als = require("gnattest.ada_ls")
 
-  local subr_name = als.get_subprogram_name_from_line(lnum)
+  local subr_name, range = als.get_subprogram_name_from_line(lnum)
+  local start_line = 0
+  local end_line = 0
+
   if subr_name == nil then
     return nil
+  end
+
+  if range and range.start and range.start.line then
+    start_line = range.start.line
+  end
+  if range and range.end_ and range.end_.line then
+    end_line = range.end_.line
   end
 
   local filename = utils.split_filename(utils.get_filename())
@@ -244,14 +263,14 @@ function M.get_gnattest_info_on_line(lnum)
             and vim.fn.match(info.source.name, subr_name) ~= -1
           or utils.is_gnattest_file()
             and vim.fn.match(info.test.file, filename) == 0
-            and vim.fn.match(info.test.name, subr_name) ~= -1
+            and start_line <= lnum
+            and end_line >= lnum
         then
           return f, p, info
         end
       end
     end
   end
-
   return nil
 end
 

--- a/lua/gnattest/xml.lua
+++ b/lua/gnattest/xml.lua
@@ -104,6 +104,8 @@ function M.get_xml_info(refresh)
   local gnattest_info = {}
   local src_info = {}
   local test_cases = {}
+  local case = {}
+  local tests = {}
   local test_info = {}
   local test_query = query_test_info()
 
@@ -117,7 +119,16 @@ function M.get_xml_info(refresh)
         local test_text =
           vim.treesitter.get_node_text(test_node, buf_id):gsub('"', "")
         local capture_id = test_query.captures[id]
-        if capture_id == "src" then
+        if capture_id == "tag" then
+          if next(gnattest_info) ~= nil then
+            table.insert(pkg_info, gnattest_info)
+            gnattest_info.tests = tests
+          end
+          src_info = {}
+          gnattest_info = {}
+          test_cases = {}
+          tests = {}
+        elseif capture_id == "src" then
           if test_capture_flag == "name" then
             src_info.name = test_text
           elseif test_capture_flag == "column" then
@@ -127,11 +138,13 @@ function M.get_xml_info(refresh)
           end
         elseif capture_id == "t_src" then
           if test_capture_flag == "name" then
-            test_cases.name = test_text
+            case.name = test_text
           elseif test_capture_flag == "line" then
-            test_cases.line = test_text
+            case.line = test_text
           elseif test_capture_flag == "column" then
-            test_cases.column = test_text
+            case.column = test_text
+            table.insert(test_cases, case)
+            case = {}
           end
         elseif capture_id == "tst" then
           if test_capture_flag == "file" then
@@ -144,11 +157,7 @@ function M.get_xml_info(refresh)
             test_info.name = test_text
             gnattest_info.source = src_info
             gnattest_info.source.case = test_cases
-            gnattest_info.test = test_info
-            table.insert(pkg_info, gnattest_info)
-            src_info = {}
-            gnattest_info = {}
-            test_cases = {}
+            table.insert(tests, test_info)
             test_info = {}
           end
         end
@@ -156,8 +165,13 @@ function M.get_xml_info(refresh)
         test_capture_flag = test_text
       end
       if pkg_capture_flag == "target_file" and pkg[pkg_text] == nil then
+        if next(gnattest_info) ~= nil then
+          table.insert(pkg_info, gnattest_info)
+          gnattest_info.tests = tests
+        end
         pkg[pkg_text] = pkg_info
         pkg_info = {}
+        gnattest_info = {}
       end
 
       pkg_capture_flag = pkg_text
@@ -200,8 +214,13 @@ function M.get_test_from_src_case_line(filename, line)
   for f, files in pairs(xml_info) do
     for p, pkg_info in pairs(files) do
       for _, test_info in pairs(pkg_info) do
-        if f == filename and tonumber(test_info.source.case.line) == line then
-          return f, p, test_info
+        for c, case in ipairs(test_info.source.case) do
+          if f == filename and tonumber(case.line) == line then
+            local info = vim.deepcopy(test_info)
+            info.source.case = case
+            info.tests = test_info.tests[c]
+            return f, p, info
+          end
         end
       end
     end
@@ -259,14 +278,20 @@ function M.get_gnattest_info_on_line(lnum)
       for _, info in pairs(pkg_info) do
         if
           not utils.is_gnattest_file()
-            and vim.fn.match(f, filename) == 0
-            and vim.fn.match(info.source.name, subr_name) ~= -1
-          or utils.is_gnattest_file()
-            and vim.fn.match(info.test.file, filename) == 0
-            and start_line <= lnum
-            and end_line >= lnum
+          and vim.fn.match(f, filename) == 0
+          and vim.fn.match(info.source.name, subr_name) ~= -1
         then
           return f, p, info
+        elseif utils.is_gnattest_file() then
+          for _, test in ipairs(info.tests) do
+            if
+              vim.fn.match(test.file, filename) == 0
+              and start_line <= lnum
+              and end_line >= lnum
+            then
+              return f, p, info
+            end
+          end
         end
       end
     end

--- a/spec/navigation_spec.lua
+++ b/spec/navigation_spec.lua
@@ -32,11 +32,13 @@ describe("gnattest.navigation", function()
         line = opts.source_line or 10,
         column = opts.source_column or 5,
       },
-      test = {
-        name = test_name,
-        file = opts.test_file or "test_file.adb",
-        line = opts.test_line or 20,
-        column = opts.test_column or 10,
+      tests = {
+        {
+          name = test_name,
+          file = opts.test_file or "test_file.adb",
+          line = opts.test_line or 20,
+          column = opts.test_column or 10,
+        },
       },
     }
   end

--- a/spec/picker_spec.lua
+++ b/spec/picker_spec.lua
@@ -81,17 +81,17 @@ describe("gnattest.picker", function()
           PkgA = {
             {
               source = { name = "Init", line = "10", column = "5" },
-              test = { file = "test_a.adb", line = "15", column = "3" },
+              tests = { { file = "test_a.adb", line = "15", column = "3" } },
             },
             {
               source = { name = "Read", line = "20", column = "5" },
-              test = { file = "test_a.adb", line = "25", column = "3" },
+              tests = { { file = "test_a.adb", line = "25", column = "3" } },
             },
           },
           PkgB = {
             {
               source = { name = "Write", line = "30", column = "5" },
-              test = { file = "test_b.adb", line = "35", column = "3" },
+              tests = { { file = "test_b.adb", line = "35", column = "3" } },
             },
           },
         },

--- a/spec/runner_spec.lua
+++ b/spec/runner_spec.lua
@@ -68,7 +68,7 @@ describe("gnattest.runner", function()
     package.loaded["gnattest.ada_ls"] = ada_ls_mock
 
     xml_mock = {
-      get_test_from_src_file_line = require("luassert.stub")
+      get_test_from_src_case_line = require("luassert.stub")
         .new()
         .returns(nil, nil, nil),
     }
@@ -256,7 +256,7 @@ describe("gnattest.runner", function()
         mock_system_async()
         runner.run_test()
 
-        xml_mock.get_test_from_src_file_line.returns("source.ads", "Pkg", {
+        xml_mock.get_test_from_src_case_line.returns("source.ads", "Pkg", {
           source = { name = "My_Proc" },
           test = { line = "10", column = "5", file = "test.adb" },
         })
@@ -276,7 +276,7 @@ describe("gnattest.runner", function()
         runner.run_test()
         runner.run_test() -- pending = 2
 
-        xml_mock.get_test_from_src_file_line.returns("source.ads", "Pkg", {
+        xml_mock.get_test_from_src_case_line.returns("source.ads", "Pkg", {
           source = { name = "My_Proc" },
           test = { line = "10", column = "5", file = "test.adb" },
         })

--- a/spec/runner_spec.lua
+++ b/spec/runner_spec.lua
@@ -189,7 +189,7 @@ describe("gnattest.runner", function()
         function()
           local test_info = {
             source = { name = "My_Proc" },
-            test = { line = "10", column = "5", file = "test.adb" },
+            tests = { line = "10", column = "5", file = "test.adb" },
           }
 
           local item = runner.prepare_qf_item(
@@ -211,7 +211,7 @@ describe("gnattest.runner", function()
         utils_mock.find_file.returns(nil)
         local test_info = {
           source = { name = "My_Proc" },
-          test = { line = "10", column = "5", file = "missing.adb" },
+          tests = { line = "10", column = "5", file = "missing.adb" },
         }
 
         runner.prepare_qf_item("Pkg", test_info, "corresponding test")
@@ -258,7 +258,7 @@ describe("gnattest.runner", function()
 
         xml_mock.get_test_from_src_case_line.returns("source.ads", "Pkg", {
           source = { name = "My_Proc" },
-          test = { line = "10", column = "5", file = "test.adb" },
+          tests = { line = "10", column = "5", file = "test.adb" },
         })
         utils_mock.find_file.returns("/found/test.adb")
 
@@ -278,7 +278,7 @@ describe("gnattest.runner", function()
 
         xml_mock.get_test_from_src_case_line.returns("source.ads", "Pkg", {
           source = { name = "My_Proc" },
-          test = { line = "10", column = "5", file = "test.adb" },
+          tests = { line = "10", column = "5", file = "test.adb" },
         })
 
         runner.on_exit_tests({

--- a/spec/xml_spec.lua
+++ b/spec/xml_spec.lua
@@ -472,14 +472,14 @@ describe("gnattest.xml", function()
             pkg1 = {
               {
                 source = { name = "test1", line = "10", column = "2" },
-                test = { name = "test_test1", file = "test.ads" },
+                tests = { { name = "test_test1", file = "test.ads" } },
               },
             },
           },
         })
         local result, filename = xml.get_test_by_name("pkg1", "test1")
         assert.equals("test1", result.source.name)
-        assert.equals("test.ads", result.test.file)
+        assert.equals("test.ads", result.tests[1].file)
         assert.equals("10", result.source.line)
         assert.equals("2", result.source.column)
         assert.equals("file1", filename)
@@ -531,8 +531,8 @@ describe("gnattest.xml", function()
           ["my_package.ads"] = {
             Package1 = {
               {
-                source = { name = "My_Function", case = { line = "10" } },
-                test = { name = "Test_My_Function", file = "test.adb" },
+                source = { name = "My_Function", case = { { line = "10" } } },
+                tests = { { name = "Test_My_Function", file = "test.adb" } },
               },
             },
           },
@@ -583,8 +583,8 @@ describe("gnattest.xml", function()
           ["my_package.ads"] = {
             Package1 = {
               {
-                source = { name = "My_Function", case = { line = "10" } },
-                test = { name = "Test_My_Function", file = "test.adb" },
+                source = { name = "My_Function", case = { { line = "10" } } },
+                tests = { { name = "Test_My_Function", file = "test.adb" } },
               },
             },
           },
@@ -653,11 +653,13 @@ describe("gnattest.xml", function()
             Package1 = {
               {
                 source = { name = "My_Function", line = "10", column = "2" },
-                test = {
-                  name = "Test_My_Function",
-                  file = "test.adb",
-                  line = "20",
-                  column = "4",
+                tests = {
+                  {
+                    name = "Test_My_Function",
+                    file = "test.adb",
+                    line = "20",
+                    column = "4",
+                  },
                 },
               },
             },
@@ -685,11 +687,13 @@ describe("gnattest.xml", function()
             Package1 = {
               {
                 source = { name = "My_Function", line = "10", column = "2" },
-                test = {
-                  name = "Test_My_Function",
-                  file = "test_file.adb",
-                  line = "20",
-                  column = "4",
+                tests = {
+                  {
+                    name = "Test_My_Function",
+                    file = "test_file.adb",
+                    line = "20",
+                    column = "4",
+                  },
                 },
               },
             },
@@ -700,7 +704,7 @@ describe("gnattest.xml", function()
 
         assert.equals("my_package.ads", file)
         assert.equals("Package1", pkg)
-        assert.equals("Test_My_Function", info.test.name)
+        assert.equals("Test_My_Function", info.tests[1].name)
       end)
 
       it("returns nil when no matches", function()
@@ -709,11 +713,13 @@ describe("gnattest.xml", function()
             Package1 = {
               {
                 source = { name = "Other_Function", line = "10", column = "2" },
-                test = {
-                  name = "Test_Other_Function",
-                  file = "test_file.adb",
-                  line = "20",
-                  column = "4",
+                tests = {
+                  {
+                    name = "Test_Other_Function",
+                    file = "test_file.adb",
+                    line = "20",
+                    column = "4",
+                  },
                 },
               },
             },
@@ -904,11 +910,13 @@ describe("gnattest.xml", function()
                   line = "10",
                   column = "5",
                 },
-                test = {
-                  name = "test_add_positive",
-                  file = "test.ads",
-                  line = "50",
-                  column = "3",
+                tests = {
+                  {
+                    name = "test_add_positive",
+                    file = "test.ads",
+                    line = "50",
+                    column = "3",
+                  },
                 },
               },
             },
@@ -927,22 +935,24 @@ describe("gnattest.xml", function()
             ["test_pkg"] = {
               {
                 source = { name = "proc" },
-                test = {
-                  name = "test_proc",
-                  file = "test.ads",
-                  line = "100",
-                  column = "3",
+                tests = {
+                  {
+                    name = "test_proc",
+                    file = "test.ads",
+                    line = "100",
+                    column = "3",
+                  },
                 },
               },
             },
           },
         })
         local test =
-          xml.get_xml_info()["src/my_package.ads"]["test_pkg"][1].test
-        assert.equals("test_proc", test.name)
-        assert.equals("test.ads", test.file)
-        assert.equals("100", test.line)
-        assert.equals("3", test.column)
+          xml.get_xml_info()["src/my_package.ads"]["test_pkg"][1].tests
+        assert.equals("test_proc", test[1].name)
+        assert.equals("test.ads", test[1].file)
+        assert.equals("100", test[1].line)
+        assert.equals("3", test[1].column)
       end)
 
       it("handles multiple test packages in same file", function()

--- a/spec/xml_spec.lua
+++ b/spec/xml_spec.lua
@@ -340,6 +340,167 @@ describe("gnattest.xml", function()
     end)
   end)
 
+  describe("tag and t_src parsing branches", function()
+    it(
+      "exercises tag push, t_src assignment, and pkg-level leftover push",
+      function()
+        _G.vim.fs.find = function()
+          return { "gnattest.xml" }
+        end
+        _G.vim.fn.readfile = function()
+          return { "<tests></tests>" }
+        end
+        _G.vim.treesitter.get_parser = function()
+          return {
+            parse = function()
+              return {
+                {
+                  root = function()
+                    return "root"
+                  end,
+                },
+              }
+            end,
+          }
+        end
+
+        _G.vim.treesitter.query.parse = function(_, query_str)
+          if query_str:find("test_unit") then
+            return {
+              captures = { "ptext" },
+              iter_captures = function()
+                local captures = { { 1, "pkg_tgt" }, { 1, "pkg_name" } }
+                local i = 0
+                return function()
+                  i = i + 1
+                  if i <= #captures then
+                    return captures[i][1], captures[i][2]
+                  end
+                end
+              end,
+            }
+          elseif query_str:find("unit") then
+            return {
+              captures = { "source_file" },
+              iter_captures = function()
+                local captures = { { 1, "unit_src" }, { 1, "unit_file" } }
+                local i = 0
+                return function()
+                  i = i + 1
+                  if i <= #captures then
+                    return captures[i][1], captures[i][2]
+                  end
+                end
+              end,
+            }
+          else
+            local pkg_n = 0
+            return {
+              captures = {
+                "tag",
+                "string",
+                "src",
+                "t_tag",
+                "t_string",
+                "t_src",
+                "string",
+                "tst",
+              },
+              iter_captures = function()
+                pkg_n = pkg_n + 1
+                local seq
+                if pkg_n == 1 then
+                  seq = {
+                    -- First <tested>: tag with no pending info → just reset
+                    { 1, "tag1" },
+                    { 2, "f_name" },
+                    { 3, "src_name" },
+                    { 2, "f_line" },
+                    { 3, "src_line" },
+                    { 2, "f_col" },
+                    { 3, "src_col" },
+                    -- test_case with t_src branch
+                    { 4, "t_tag1" },
+                    { 5, "tc_name" },
+                    { 6, "ts_name" },
+                    { 5, "tc_line" },
+                    { 6, "ts_line" },
+                    { 5, "tc_col" },
+                    { 6, "ts_col" },
+                    -- test entry
+                    { 7, "f_file" },
+                    { 8, "tst_file" },
+                    { 7, "f_line" },
+                    { 8, "tst_line" },
+                    { 7, "f_col" },
+                    { 8, "tst_col" },
+                    { 7, "f_name" },
+                    { 8, "tst_name" },
+                    -- Second <tested>: tag WITH pending gnattest_info → push
+                    { 1, "tag2" },
+                  }
+                else
+                  seq = {
+                    -- Single <tested>: populate gnattest_info for pkg-level push
+                    { 1, "tag1" },
+                    { 2, "f_name" },
+                    { 3, "src_name2" },
+                    { 7, "f_name" },
+                    { 8, "tst_name2" },
+                  }
+                end
+                local i = 0
+                return function()
+                  i = i + 1
+                  if i <= #seq then
+                    return seq[i][1], seq[i][2]
+                  end
+                end
+              end,
+            }
+          end
+        end
+
+        _G.vim.treesitter.get_node_text = function(node)
+          local map = {
+            unit_src = "source_file",
+            unit_file = "file.ads",
+            pkg_tgt = "target_file",
+            pkg_name = "Pkg1",
+            tag1 = "tag1",
+            tag2 = "tag2",
+            f_name = "name",
+            f_line = "line",
+            f_col = "column",
+            f_file = "file",
+            src_name = "Fn1",
+            src_line = "10",
+            src_col = "5",
+            src_name2 = "Fn2",
+            t_tag1 = "t_tag",
+            tc_name = "name",
+            tc_line = "line",
+            tc_col = "column",
+            ts_name = "My_Case",
+            ts_line = "50",
+            ts_col = "3",
+            tst_file = "test.adb",
+            tst_line = "15",
+            tst_col = "3",
+            tst_name = "Test_Fn1",
+            tst_name2 = "Test_Fn2",
+          }
+          return map[node] or node
+        end
+
+        local result = xml.get_xml_info()
+        assert.is_table(result)
+        assert.is_not_nil(result["file.ads"])
+        assert.is_not_nil(result["file.ads"]["Pkg1"])
+      end
+    )
+  end)
+
   describe("XML parsing logic coverage tests", function()
     describe("core data structure population", function()
       it("populates source_files table from unit captures", function()
@@ -392,6 +553,14 @@ describe("gnattest.xml", function()
         local result = xml.get_xml_info()
         assert.is_not_nil(result["package_a.ads"])
         assert.is_not_nil(result["package_b.ads"])
+      end)
+
+      it("returns nil when gnattest.xml not found", function()
+        _G.vim.fs.find = function()
+          return {}
+        end
+
+        assert.is_nil(xml.get_xml_info())
       end)
     end)
 
@@ -1009,6 +1178,28 @@ describe("gnattest.xml", function()
         local buf_id = xml._create_xml_buf()
         assert.equals(1, buf_id)
       end)
+
+      it(
+        "_create_xml_buf returns nil and notifies when gnattest.xml not found",
+        function()
+          _G.vim.fs.find = function()
+            return {}
+          end
+          local notified = false
+          local utils = require("gnattest.utils")
+          local orig_notify = utils.notify
+          utils.notify = function(_, lvl)
+            notified = true
+            assert.equals(vim.log.levels.ERROR, lvl)
+          end
+
+          local result = xml._create_xml_buf()
+          assert.is_nil(result)
+          assert.is_true(notified)
+
+          utils.notify = orig_notify
+        end
+      )
 
       it(
         "_create_xml_buf executes file pattern matching in vim.fs.find callback",

--- a/spec/xml_spec.lua
+++ b/spec/xml_spec.lua
@@ -120,7 +120,7 @@ describe("gnattest.xml", function()
       assert.is_function(xml.get_test_by_name)
       assert.is_function(xml.get_xml_info)
       assert.is_function(xml.get_pkg_tests)
-      assert.is_function(xml.get_test_from_src_file_line)
+      assert.is_function(xml.get_test_from_src_case_line)
       assert.is_function(xml.get_gnattest_info_on_line)
       assert.is_function(xml.get_gnattest_info_on_cursor)
     end)
@@ -525,13 +525,13 @@ describe("gnattest.xml", function()
       end)
     end)
 
-    describe("get_test_from_src_file_line", function()
+    describe("get_test_from_src_case_line", function()
       it("finds test by filename and line", function()
         xml = inject_xml_data({
           ["my_package.ads"] = {
             Package1 = {
               {
-                source = { name = "My_Function", line = "10", column = "2" },
+                source = { name = "My_Function", case = { line = "10" } },
                 test = { name = "Test_My_Function", file = "test.adb" },
               },
             },
@@ -539,7 +539,7 @@ describe("gnattest.xml", function()
         })
 
         local file, pkg, info =
-          xml.get_test_from_src_file_line("my_package.ads", 10)
+          xml.get_test_from_src_case_line("my_package.ads", 10)
 
         assert.equals("my_package.ads", file)
         assert.equals("Package1", pkg)
@@ -574,7 +574,7 @@ describe("gnattest.xml", function()
           { unit_flag = "source_file", unit_file = "my_file.ads" }
         )
 
-        assert.is_nil(xml.get_test_from_src_file_line("my_package.ads", 10))
+        assert.is_nil(xml.get_test_from_src_case_line("my_package.ads", 10))
         assert.equals(1, parse_calls)
       end)
 
@@ -583,14 +583,14 @@ describe("gnattest.xml", function()
           ["my_package.ads"] = {
             Package1 = {
               {
-                source = { name = "My_Function", line = "10", column = "2" },
+                source = { name = "My_Function", case = { line = "10" } },
                 test = { name = "Test_My_Function", file = "test.adb" },
               },
             },
           },
         })
 
-        assert.is_nil(xml.get_test_from_src_file_line("my_package.ads", 11))
+        assert.is_nil(xml.get_test_from_src_case_line("my_package.ads", 11))
       end)
     end)
 
@@ -604,7 +604,11 @@ describe("gnattest.xml", function()
         original_get_subprogram =
           require("gnattest.ada_ls").get_subprogram_name_from_line
         require("gnattest.ada_ls").get_subprogram_name_from_line = function()
-          return "My_Function"
+          return "My_Function",
+            {
+              start = { line = 0, character = 0 },
+              end_ = { line = 999, character = 999 },
+            }
         end
 
         local utils = require("gnattest.utils")


### PR DESCRIPTION
Extends the XML parsing to support multiple test cases per source subprogram. Previously, each source subprogram mapped to a single test; now the data structure supports multiple test cases (e.g., for different input scenarios) each with their own corresponding test.

Changes

- Refactored XML parsing to capture test_case aspects and build a tests array per subprogram
- Updated navigation, picker, and runner modules to work with the new data structure
- Fixed gnattest file detection for relative paths returned by ALS
- Increased test coverage with new test cases for the parsing logic
